### PR TITLE
Only round numbers when a player will see them

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -38,6 +38,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.time.DayOfWeek;
 import java.util.*;
 import java.util.function.Consumer;
@@ -586,10 +588,22 @@ public class FishUtils {
      * @param places The amount of decimal places to round to.
      * @return The rounded double value with the provided amount of decimal places.
      */
-    public static double roundDouble(final double value, int places) {
+    public static double roundDouble(final double value, final int places) {
         return new BigDecimal(value)
             .setScale(places, RoundingMode.HALF_UP)
             .doubleValue();
+    }
+
+    /**
+     * Formats a double value by applying the configured decimal format.
+     *
+     * @param value The double value to be formatted.
+     * @return The formatted double
+     */
+    public static String formatDouble(final double value) {
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(MainConfig.getInstance().getDecimalLocale());
+        DecimalFormat format = new DecimalFormat(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getLegacyMessage(), symbols);
+        return format.format(value);
     }
 
     /**
@@ -603,6 +617,18 @@ public class FishUtils {
         return new BigDecimal(value)
             .setScale(places, RoundingMode.HALF_UP)
             .floatValue();
+    }
+
+    /**
+     * Formats a float value by applying the configured decimal format.
+     *
+     * @param value The float value to be formatted.
+     * @return The formatted float
+     */
+    public static String formatFloat(final float value) {
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(MainConfig.getInstance().getDecimalLocale());
+        DecimalFormat format = new DecimalFormat(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getLegacyMessage(), symbols);
+        return format.format(value);
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -36,9 +36,8 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jooq.impl.QOM;
-
-import java.text.DecimalFormat;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.DayOfWeek;
 import java.util.*;
 import java.util.function.Consumer;
@@ -46,7 +45,6 @@ import java.util.stream.Stream;
 
 
 public class FishUtils {
-    public static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#.0");
 
     private FishUtils() {
         throw new UnsupportedOperationException();
@@ -579,6 +577,32 @@ public class FishUtils {
         }
 
         return new ItemStack(material);
+    }
+
+    /**
+     * Sorts a double value by rounding it to the provided amount of decimal places.
+     *
+     * @param value The double value to be sorted.
+     * @param places The amount of decimal places to round to.
+     * @return The rounded double value with the provided amount of decimal places.
+     */
+    public static double roundDouble(final double value, int places) {
+        return new BigDecimal(value)
+            .setScale(places, RoundingMode.HALF_UP)
+            .doubleValue();
+    }
+
+    /**
+     * Sorts a float value by rounding it to the provided amount of decimal places.
+     *
+     * @param value The float value to be sorted.
+     * @param places The amount of decimal places to round to.
+     * @return The rounded float value with the provided amount of decimal places.
+     */
+    public static float roundFloat(final float value, int places) {
+        return new BigDecimal(value)
+            .setScale(places, RoundingMode.HALF_UP)
+            .floatValue();
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -600,9 +600,9 @@ public class FishUtils {
      * @param value The double value to be formatted.
      * @return The formatted double
      */
-    public static String formatDouble(final double value) {
+    public static String formatDouble(@NotNull final String formatStr, final double value) {
         DecimalFormatSymbols symbols = new DecimalFormatSymbols(MainConfig.getInstance().getDecimalLocale());
-        DecimalFormat format = new DecimalFormat(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getLegacyMessage(), symbols);
+        DecimalFormat format = new DecimalFormat(formatStr, symbols);
         return format.format(value);
     }
 
@@ -625,9 +625,9 @@ public class FishUtils {
      * @param value The float value to be formatted.
      * @return The formatted float
      */
-    public static String formatFloat(final float value) {
+    public static String formatFloat(@NotNull final String formatStr, final float value) {
         DecimalFormatSymbols symbols = new DecimalFormatSymbols(MainConfig.getInstance().getDecimalLocale());
-        DecimalFormat format = new DecimalFormat(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getLegacyMessage(), symbols);
+        DecimalFormat format = new DecimalFormat(formatStr, symbols);
         return format.format(value);
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
@@ -183,7 +183,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
             }
             
             if (value != -1.0f) {
-                return FishUtils.formatFloat(value);
+                return Double.toString(FishUtils.roundDouble(value, 1));
             } else {
                 return "";
             }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
@@ -183,7 +183,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
             }
             
             if (value != -1.0f) {
-                return Float.toString(Math.round(value * 10f) / 10f);
+                return Double.toString(FishUtils.roundDouble(value, 1));
             } else {
                 return "";
             }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
@@ -183,7 +183,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
             }
             
             if (value != -1.0f) {
-                return Double.toString(FishUtils.roundDouble(value, 1));
+                return FishUtils.formatFloat(value);
             } else {
                 return "";
             }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
@@ -309,7 +309,7 @@ public class Database implements DatabaseAPI {
                         .set(Tables.FISH.FISH_RARITY, fish.getRarity().getId())
                         .set(Tables.FISH.FIRST_FISHER, uuid.toString())
                         .set(Tables.FISH.TOTAL_CAUGHT, 1)
-                        .set(Tables.FISH.LARGEST_FISH, (float) FishUtils.roundDouble(fish.getLength(), 1))
+                        .set(Tables.FISH.LARGEST_FISH, fish.getLength())
                         .set(Tables.FISH.FIRST_FISHER, uuid.toString())
                         .set(Tables.FISH.LARGEST_FISHER, uuid.toString())
                         .set(Tables.FISH.FIRST_CATCH_TIME, LocalDateTime.now())
@@ -357,7 +357,7 @@ public class Database implements DatabaseAPI {
             @Override
             protected int onRunUpdate(DSLContext dslContext) {
                 return dslContext.update(Tables.FISH)
-                        .set(Tables.FISH.LARGEST_FISH, (float) FishUtils.roundDouble(fish.getLength(), 1)) // TODO use decimal format
+                        .set(Tables.FISH.LARGEST_FISH, fish.getLength()) // TODO use decimal format
                         .set(Tables.FISH.LARGEST_FISHER, uuid.toString())
                         .where(Tables.FISH.FISH_RARITY.eq(fish.getRarity().getId()).and(Tables.FISH.FISH_NAME.eq(fish.getName())))
                         .execute();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
@@ -2,6 +2,7 @@ package com.oheers.fish.database;
 
 
 import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.FishUtils;
 import com.oheers.fish.competition.Competition;
 import com.oheers.fish.competition.CompetitionEntry;
 import com.oheers.fish.competition.leaderboard.Leaderboard;
@@ -308,7 +309,7 @@ public class Database implements DatabaseAPI {
                         .set(Tables.FISH.FISH_RARITY, fish.getRarity().getId())
                         .set(Tables.FISH.FIRST_FISHER, uuid.toString())
                         .set(Tables.FISH.TOTAL_CAUGHT, 1)
-                        .set(Tables.FISH.LARGEST_FISH, Math.round(fish.getLength() * 10f) / 10f)
+                        .set(Tables.FISH.LARGEST_FISH, (float) FishUtils.roundDouble(fish.getLength(), 1))
                         .set(Tables.FISH.FIRST_FISHER, uuid.toString())
                         .set(Tables.FISH.LARGEST_FISHER, uuid.toString())
                         .set(Tables.FISH.FIRST_CATCH_TIME, LocalDateTime.now())
@@ -356,7 +357,7 @@ public class Database implements DatabaseAPI {
             @Override
             protected int onRunUpdate(DSLContext dslContext) {
                 return dslContext.update(Tables.FISH)
-                        .set(Tables.FISH.LARGEST_FISH, Math.round(fish.getLength() * 10f) / 10f /* todo use decimal format */)
+                        .set(Tables.FISH.LARGEST_FISH, (float) FishUtils.roundDouble(fish.getLength(), 1)) // TODO use decimal format
                         .set(Tables.FISH.LARGEST_FISHER, uuid.toString())
                         .where(Tables.FISH.FISH_RARITY.eq(fish.getRarity().getId()).and(Tables.FISH.FISH_NAME.eq(fish.getName())))
                         .execute();
@@ -551,7 +552,7 @@ public class Database implements DatabaseAPI {
                         .set(Tables.USERS_SALES.FISH_RARITY, fishRarity)
                         .set(Tables.USERS_SALES.FISH_AMOUNT, fishAmount)
                         .set(Tables.USERS_SALES.FISH_LENGTH, fishLength)
-                        .set(Tables.USERS_SALES.PRICE_SOLD, Math.round(priceSold * 10) / 10.0) //todo use decimal format, or a util command
+                        .set(Tables.USERS_SALES.PRICE_SOLD, priceSold)
                         .execute();
             }
         }.executeUpdate();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/economy/VaultEconomyType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/economy/VaultEconomyType.java
@@ -101,10 +101,7 @@ public class VaultEconomyType implements EconomyType {
             message.setVariable("{amount}", String.valueOf(worth));
             return message.getLegacyMessage();
         }
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(MainConfig.getInstance().getDecimalLocale());
-        DecimalFormat format = new DecimalFormat(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getLegacyMessage(), symbols);
-        double roundedWorth = FishUtils.roundDouble(worth, 1);
-        return format.format(roundedWorth);
+        return FishUtils.formatDouble(worth);
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/economy/VaultEconomyType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/economy/VaultEconomyType.java
@@ -1,6 +1,7 @@
 package com.oheers.fish.economy;
 
 import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.FishUtils;
 import com.oheers.fish.api.adapter.AbstractMessage;
 import com.oheers.fish.api.economy.EconomyType;
 import com.oheers.fish.config.MainConfig;
@@ -76,10 +77,11 @@ public class VaultEconomyType implements EconomyType {
 
     @Override
     public double prepareValue(double value, boolean applyMultiplier) {
+        double finalValue = value;
         if (applyMultiplier) {
-            return value * getMultiplier();
+            finalValue = value * getMultiplier();
         }
-        return value;
+        return finalValue;
     }
 
     @Override
@@ -101,7 +103,8 @@ public class VaultEconomyType implements EconomyType {
         }
         DecimalFormatSymbols symbols = new DecimalFormatSymbols(MainConfig.getInstance().getDecimalLocale());
         DecimalFormat format = new DecimalFormat(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getLegacyMessage(), symbols);
-        return format.format(worth);
+        double roundedWorth = FishUtils.roundDouble(worth, 1);
+        return format.format(roundedWorth);
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/economy/VaultEconomyType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/economy/VaultEconomyType.java
@@ -101,7 +101,7 @@ public class VaultEconomyType implements EconomyType {
             message.setVariable("{amount}", String.valueOf(worth));
             return message.getLegacyMessage();
         }
-        return FishUtils.formatDouble(worth);
+        return FishUtils.formatDouble(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getLegacyMessage(), worth);
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
@@ -65,7 +65,6 @@ public class SellHelper {
 
         List<SoldFish> soldFish = getTotalSoldFish();
         double totalWorth = getTotalWorth(soldFish);
-        double sellPrice = Math.floor(totalWorth * 10) / 10;
 
         // Remove sold items
         for (ItemStack item : getPossibleSales()) {
@@ -88,7 +87,7 @@ public class SellHelper {
         // sending the sell message to the player
 
         AbstractMessage message = ConfigMessage.FISH_SALE.getMessage();
-        message.setSellPrice(economy.getWorthFormat(sellPrice, true));
+        message.setSellPrice(economy.getWorthFormat(totalWorth, true));
         message.setAmount(Integer.toString(fishCount));
         message.setPlayer(this.player);
         message.send(player);
@@ -155,7 +154,7 @@ public class SellHelper {
         }
         this.fishCount = count;
 
-        return Math.floor(totalValue * 10) / 10;
+        return totalValue;
     }
 
     private void logSoldFish(final UUID uuid, @NotNull List<SoldFish> soldFish) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/WorthNBT.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/WorthNBT.java
@@ -93,9 +93,7 @@ public class WorthNBT {
     }
 
     private static double getMultipliedValue(Float length, String rarity, String name) {
-        double worthMultiplier = getWorthMultiplier(rarity, name);
-        double value = multipleWorthByLength(worthMultiplier, length);
-        return sortFunkyDecimals(value);
+        return getWorthMultiplier(rarity, name) * length;
     }
 
     private static double getWorthMultiplier(final String rarityStr, final String name) {
@@ -116,26 +114,4 @@ public class WorthNBT {
         return value;
     }
 
-    /**
-     * Calculates the worth of an item based on a given worth multiplier and length.
-     *
-     * @param worthMultiplier The multiplier to apply to the length value.
-     * @param length The length value to be multiplied.
-     * @return The calculated worth of the item.
-     */
-    private static double multipleWorthByLength(final double worthMultiplier, final Float length) {
-        return worthMultiplier * length;
-    }
-
-
-    /**
-     * Sorts a double value by rounding it to the nearest whole number with one decimal place.
-     *
-     * @param value The double value to be sorted.
-     * @return The rounded double value with one decimal place.
-     */
-    // Sorts out funky decimals during the above multiplication.
-    private static double sortFunkyDecimals(final double value) {
-        return Math.round(value * 10.0) / 10.0;
-    }
 }


### PR DESCRIPTION
## Description
Only round numbers when a player will see them to ensure accurate values.

---

### What has changed?
- Added rounding methods to FishUtils
- All rounding code has been removed apart from in VaultEconomyType#formatWorth and the Sell GUI placeholders

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.