### PR TITLE
Cleans up some API classes

### DIFF
--- a/even-more-fish-addons-j21/build.gradle.kts
+++ b/even-more-fish-addons-j21/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 
 repositories {
-    maven("https://repo.nexomc.com/snapshots/")
+    maven("https://repo.nexomc.com/releases/")
     maven("https://repo.oraxen.com/releases")
 }
 

--- a/even-more-fish-addons-j21/src/main/java/com/oheers/evenmorefish/addons/NexoItemAddon.java
+++ b/even-more-fish-addons-j21/src/main/java/com/oheers/evenmorefish/addons/NexoItemAddon.java
@@ -11,8 +11,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 
 public class NexoItemAddon extends ItemAddon implements Listener {
-
-    private boolean nexoLoaded = false;
     
     @Override
     public String getPrefix() {
@@ -36,7 +34,11 @@ public class NexoItemAddon extends ItemAddon implements Listener {
 
     @Override
     public ItemStack getItemStack(String id) {
-        if (!nexoLoaded) {
+        for (ItemBuilder itemBuilder : NexoItems.items()) {
+            System.out.println(itemBuilder.);
+        }
+        if (!NexoItems.exists(id)) {
+            getLogger().warning(() -> "Nexo item with id %s doesn't exist.".formatted(id));
             return null;
         }
 
@@ -46,6 +48,7 @@ public class NexoItemAddon extends ItemAddon implements Listener {
             getLogger().info(() -> String.format("Could not obtain Nexo item %s", id));
             return null;
         }
+
         return item.build();
     }
 
@@ -53,7 +56,6 @@ public class NexoItemAddon extends ItemAddon implements Listener {
     public void onItemsLoad(NexoItemsLoadedEvent event) {
         getLogger().info("Detected that Nexo has finished loading all items...");
         getLogger().info("Reloading EMF.");
-        this.nexoLoaded = true;
 
         EMFPlugin.getInstance().reload(null);
     }

--- a/even-more-fish-addons-j21/src/main/java/com/oheers/evenmorefish/addons/NexoItemAddon.java
+++ b/even-more-fish-addons-j21/src/main/java/com/oheers/evenmorefish/addons/NexoItemAddon.java
@@ -34,9 +34,6 @@ public class NexoItemAddon extends ItemAddon implements Listener {
 
     @Override
     public ItemStack getItemStack(String id) {
-        for (ItemBuilder itemBuilder : NexoItems.items()) {
-            System.out.println(itemBuilder.);
-        }
         if (!NexoItems.exists(id)) {
             getLogger().warning(() -> "Nexo item with id %s doesn't exist.".formatted(id));
             return null;

--- a/even-more-fish-addons-j21/src/main/java/com/oheers/evenmorefish/addons/OraxenItemAddon.java
+++ b/even-more-fish-addons-j21/src/main/java/com/oheers/evenmorefish/addons/OraxenItemAddon.java
@@ -11,6 +11,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 
 public class OraxenItemAddon extends ItemAddon implements Listener {
+
     @Override
     public String getPrefix() {
         return "oraxen";

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/adapter/PlatformAdapter.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/adapter/PlatformAdapter.java
@@ -1,8 +1,11 @@
 package com.oheers.fish.api.adapter;
 
+import com.oheers.fish.api.plugin.EMFPlugin;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.UUID;
 
 public abstract class PlatformAdapter {
 
@@ -23,5 +26,20 @@ public abstract class PlatformAdapter {
     public abstract AbstractMessage createMessage(@NotNull String message);
 
     public abstract AbstractMessage createMessage(@NotNull List<String> messageList);
+
+    public abstract ItemStack getSkullFromBase64(@NotNull String base64);
+
+    public abstract ItemStack getSkullFromUUID(@NotNull UUID uuid);
+
+    public ItemStack getSkullFromUUID(@NotNull String uuidStr) {
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(uuidStr);
+        } catch (IllegalArgumentException e) {
+            EMFPlugin.getInstance().getLogger().warning("Invalid UUID provided for skull: " + uuidStr);
+            return null;
+        }
+        return getSkullFromUUID(uuid);
+    }
 
 }

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/plugin/EMFPlugin.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/plugin/EMFPlugin.java
@@ -9,18 +9,18 @@ public abstract class EMFPlugin extends JavaPlugin {
 
     private static EMFPlugin instance;
 
+    protected EMFPlugin() {
+        if (instance != null) {
+            throw new UnsupportedOperationException("EMFPlugin has already been assigned!");
+        }
+        instance = this;
+    }
+
     public static @NotNull EMFPlugin getInstance() {
         if (instance == null) {
             throw new RuntimeException("EMFPlugin not found. This should not happen!");
         }
         return instance;
-    }
-
-    public static void setInstance(@NotNull EMFPlugin plugin) {
-        if (instance != null) {
-            throw new UnsupportedOperationException("EMFPlugin has already been assigned!");
-        }
-        instance = plugin;
     }
 
     public abstract void reload(@Nullable CommandSender sender);

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/requirement/RequirementContext.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/requirement/RequirementContext.java
@@ -9,11 +9,12 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.ref.WeakReference;
 
 public class RequirementContext {
-    WeakReference<World> worldRef;
-    Location location;
-    Player player;
-    YamlDocument config;
-    String configPath;
+
+    private WeakReference<World> worldRef;
+    private Location location;
+    private Player player;
+    private YamlDocument config;
+    private String configPath;
 
     /**
      * Provides data about the current server to the requirement checker, for example it passes through the current
@@ -74,4 +75,5 @@ public class RequirementContext {
     public void setPlayer(Player player) {
         this.player = player;
     }
+
 }

--- a/even-more-fish-paper/src/main/java/com/oheers/fish/adapter/PaperAdapter.java
+++ b/even-more-fish-paper/src/main/java/com/oheers/fish/adapter/PaperAdapter.java
@@ -1,10 +1,17 @@
 package com.oheers.fish.adapter;
 
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.ProfileProperty;
 import com.oheers.fish.api.adapter.PlatformAdapter;
 import com.oheers.fish.api.plugin.EMFPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.UUID;
 
 public class PaperAdapter extends PlatformAdapter {
 
@@ -25,6 +32,27 @@ public class PaperAdapter extends PlatformAdapter {
     @Override
     public PaperMessage createMessage(@NotNull List<String> messageList) {
         return new PaperMessage(messageList, this);
+    }
+
+    @Override
+    public ItemStack getSkullFromBase64(@NotNull String base64) {
+        ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
+        skull.editMeta(SkullMeta.class, meta -> {
+            PlayerProfile profile = Bukkit.createProfile(UUID.randomUUID(), "EMFSkull");
+            profile.setProperty(new ProfileProperty("textures", base64));
+            meta.setPlayerProfile(profile);
+        });
+        return skull;
+    }
+
+    @Override
+    public ItemStack getSkullFromUUID(@NotNull UUID uuid) {
+        ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
+        skull.editMeta(SkullMeta.class, meta -> {
+            PlayerProfile profile = Bukkit.createProfile(uuid, "EMFSkull");
+            meta.setPlayerProfile(profile);
+        });
+        return skull;
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -111,7 +111,13 @@ public class EvenMoreFish extends EMFPlugin {
     private AddonManager addonManager;
     private Map<String, String> commandUsages = new HashMap<>();
 
-    public static EvenMoreFish getInstance() {
+    public EvenMoreFish() {
+        // Assigns the EMFPlugin instance for API usage.
+        super();
+        instance = this;
+    }
+
+    public static @NotNull EvenMoreFish getInstance() {
         return instance;
     }
 
@@ -137,15 +143,11 @@ public class EvenMoreFish extends EMFPlugin {
             throw new RuntimeException("NBT-API wasn't initialized properly, disabling the plugin");
         }
 
-        // This should only ever be done once.
-        EMFPlugin.setInstance(this);
-
         CommandAPI.onEnable();
 
         // If EMF folder does not exist, this is the first load.
         firstLoad = !getDataFolder().exists();
 
-        instance = this;
         scheduler = UniversalScheduler.getScheduler(this);
         platformAdapter = loadAdapter();
 
@@ -225,12 +227,6 @@ public class EvenMoreFish extends EMFPlugin {
 
     @Override
     public void onDisable() {
-
-        // Prevent issues when NBT preload fails.
-        if (instance == null) {
-            return;
-        }
-
         CommandAPI.onDisable();
 
         terminateGUIS();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -427,6 +427,7 @@ public class EvenMoreFish extends EMFPlugin {
         });
     }
 
+    @Override
     public void reload(@Nullable CommandSender sender) {
 
         // If EMF folder does not exist, assume first load again.
@@ -688,7 +689,7 @@ public class EvenMoreFish extends EMFPlugin {
     }
 
     // FISH TOGGLE METHODS
-    // We use Strings here because Spigot 1.16.5 does not have PersistentDataType.BOOLEAN.
+    // We use Strings here because Spigot 1.18.2 does not have PersistentDataType.BOOLEAN.
 
     public void performFishToggle(@NotNull Player player) {
         NamespacedKey key = new NamespacedKey(this, "fish-enabled");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -267,18 +267,6 @@ public class FishUtils {
         return whitelistedWorlds.contains(l.getWorld().getName());
     }
 
-    public static @NotNull String translateColorCodes(String message) {
-        return EvenMoreFish.getAdapter().translateColorCodes(message);
-    }
-
-    public static @NotNull ItemStack getSkullFromBase64(String base64) {
-        return EvenMoreFish.getAdapter().getSkullFromBase64(base64); // Delegate to the platform adapter
-    }
-
-    public static @NotNull ItemStack getSkullFromUUID(UUID uuid) {
-        return EvenMoreFish.getAdapter().getSkullFromUUID(uuid); // Delegate to the platform adapter
-    }
-
     public static @NotNull String timeFormat(long timeLeft) {
         String returning = "";
         long hours = timeLeft / 3600;
@@ -532,6 +520,20 @@ public class FishUtils {
         }
 
         return new ItemStack(material);
+    }
+
+    // The following methods have been delegated to the platform adapter.
+
+    public static @NotNull String translateColorCodes(String message) {
+        return EvenMoreFish.getAdapter().translateColorCodes(message);
+    }
+
+    public static @NotNull ItemStack getSkullFromBase64(String base64) {
+        return EvenMoreFish.getAdapter().getSkullFromBase64(base64);
+    }
+
+    public static @NotNull ItemStack getSkullFromUUID(UUID uuid) {
+        return EvenMoreFish.getAdapter().getSkullFromUUID(uuid);
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -271,59 +271,12 @@ public class FishUtils {
         return EvenMoreFish.getAdapter().translateColorCodes(message);
     }
 
-    //gets the item with a custom texture
-    public static @NotNull ItemStack getSkullFromBase64(String base64EncodedString) {
-        final ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
-        UUID headUuid = UUID.randomUUID();
-        // 1.20.5+ handling
-        if (MinecraftVersion.isNewerThan(MinecraftVersion.MC1_20_R3)) {
-            NBT.modifyComponents(
-                    skull, nbt -> {
-                        ReadWriteNBT profileNbt = nbt.getOrCreateCompound("minecraft:profile");
-                        profileNbt.setUUID("id", headUuid);
-                        ReadWriteNBT propertiesNbt = profileNbt.getCompoundList("properties").addCompound();
-                        // This key is required, so we set it to an empty string.
-                        propertiesNbt.setString("name", "textures");
-                        propertiesNbt.setString("value", base64EncodedString);
-                    }
-            );
-            // 1.20.4 and below handling
-        } else {
-            NBT.modify(
-                    skull, nbt -> {
-                        ReadWriteNBT skullOwnerCompound = nbt.getOrCreateCompound("SkullOwner");
-                        skullOwnerCompound.setUUID("Id", headUuid);
-                        skullOwnerCompound.getOrCreateCompound("Properties")
-                                .getCompoundList("textures")
-                                .addCompound()
-                                .setString("Value", base64EncodedString);
-                    }
-            );
-        }
-        return skull;
+    public static @NotNull ItemStack getSkullFromBase64(String base64) {
+        return EvenMoreFish.getAdapter().getSkullFromBase64(base64); // Delegate to the platform adapter
     }
 
-    //gets the item with a custom uuid
     public static @NotNull ItemStack getSkullFromUUID(UUID uuid) {
-        final ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
-        // 1.20.5+ handling
-        if (MinecraftVersion.isNewerThan(MinecraftVersion.MC1_20_R3)) {
-            NBT.modifyComponents(
-                    skull, nbt -> {
-                        ReadWriteNBT profileNbt = nbt.getOrCreateCompound("minecraft:profile");
-                        profileNbt.setUUID("id", uuid);
-                    }
-            );
-            // 1.20.4 and below handling
-        } else {
-            NBT.modify(
-                    skull, nbt -> {
-                        ReadWriteNBT skullOwnerCompound = nbt.getOrCreateCompound("SkullOwner");
-                        skullOwnerCompound.setUUID("Id", uuid);
-                    }
-            );
-        }
-        return skull;
+        return EvenMoreFish.getAdapter().getSkullFromUUID(uuid); // Delegate to the platform adapter
     }
 
     public static @NotNull String timeFormat(long timeLeft) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/SkullSaver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/SkullSaver.java
@@ -37,6 +37,7 @@ public class SkullSaver implements Listener {
         
         ItemStack stack = block.getDrops().iterator().next().clone();
         event.setCancelled(true);
+        event.setDropItems(false);
         
         try {
             Fish f = FishUtils.getFish(skullMeta, event.getPlayer());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/adapter/SpigotAdapter.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/adapter/SpigotAdapter.java
@@ -2,9 +2,15 @@ package com.oheers.fish.adapter;
 
 import com.oheers.fish.api.adapter.PlatformAdapter;
 import com.oheers.fish.api.plugin.EMFPlugin;
+import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.iface.ReadWriteNBT;
+import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 public class SpigotAdapter extends PlatformAdapter {
@@ -29,5 +35,60 @@ public class SpigotAdapter extends PlatformAdapter {
     @Override
     public SpigotMessage createMessage(@NotNull List<String> messageList) {
         return new SpigotMessage(messageList, this);
+    }
+
+    @Override
+    public ItemStack getSkullFromBase64(@NotNull String base64) {
+        final ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
+        UUID headUuid = UUID.randomUUID();
+        // 1.20.5+ handling
+        if (MinecraftVersion.isNewerThan(MinecraftVersion.MC1_20_R3)) {
+            NBT.modifyComponents(
+                skull, nbt -> {
+                    ReadWriteNBT profileNbt = nbt.getOrCreateCompound("minecraft:profile");
+                    profileNbt.setUUID("id", headUuid);
+                    ReadWriteNBT propertiesNbt = profileNbt.getCompoundList("properties").addCompound();
+                    // This key is required, so we set it to an empty string.
+                    propertiesNbt.setString("name", "textures");
+                    propertiesNbt.setString("value", base64);
+                }
+            );
+        // 1.20.4 and below handling
+        } else {
+            NBT.modify(
+                skull, nbt -> {
+                    ReadWriteNBT skullOwnerCompound = nbt.getOrCreateCompound("SkullOwner");
+                    skullOwnerCompound.setUUID("Id", headUuid);
+                    skullOwnerCompound.getOrCreateCompound("Properties")
+                        .getCompoundList("textures")
+                        .addCompound()
+                        .setString("Value", base64);
+                }
+            );
+        }
+        return skull;
+    }
+
+    @Override
+    public ItemStack getSkullFromUUID(@NotNull UUID uuid) {
+        final ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
+        // 1.20.5+ handling
+        if (MinecraftVersion.isNewerThan(MinecraftVersion.MC1_20_R3)) {
+            NBT.modifyComponents(
+                skull, nbt -> {
+                    ReadWriteNBT profileNbt = nbt.getOrCreateCompound("minecraft:profile");
+                    profileNbt.setUUID("id", uuid);
+                }
+            );
+        // 1.20.4 and below handling
+        } else {
+            NBT.modify(
+                skull, nbt -> {
+                    ReadWriteNBT skullOwnerCompound = nbt.getOrCreateCompound("SkullOwner");
+                    skullOwnerCompound.setUUID("Id", uuid);
+                }
+            );
+        }
+        return skull;
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,7 +41,7 @@ dependencyResolutionManagement {
             library("nbt-api", "de.tr7zw:item-nbt-api:2.14.1")
             library("denizen-api", "com.denizenscript:denizen:1.3.1-SNAPSHOT")
             library("oraxen", "io.th0rgal:oraxen:1.188.0")
-            library("nexo", "com.nexomc:nexo:0.9.0-dev.9")
+            library("nexo", "com.nexomc:nexo:1.0.0")
 
             library("ecoitems-api", "com.willfp:EcoItems:5.6.1")
             library("ecoitems-libreforge", "com.willfp:libreforge:4.21.1")


### PR DESCRIPTION
## Description
Cleans up some API classes and adds new PlatformAdapter methods

---

### What has changed?
- Removed EMFPlugin#setInstance. We now assign instance in the constructor
- Skull creation has been delegated to the PlatformAdapters. The PaperAdapter uses Paper API methods instead of NBT-API.
- Disabled BlockBreakEvent drops when an EMF skull is broken as we handle that ourselves
- EvenMoreFish#reload is now an override as it should be
- Fixed RequirementContext's variables not being private
- Fixes NexoItemAddon - this needed the same fix as #553

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.