### PR TITLE
Fixes competition issues

### DIFF
--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/adapter/AbstractMessage.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/adapter/AbstractMessage.java
@@ -16,6 +16,7 @@ public abstract class AbstractMessage {
     private String message;
     private boolean canSilent = false;
     private OfflinePlayer relevantPlayer;
+    protected boolean perPlayer = true;
 
     protected AbstractMessage(@NotNull final String message, @NotNull PlatformAdapter platformAdapter) {
         this.message = formatColours(message);
@@ -58,6 +59,10 @@ public abstract class AbstractMessage {
             String replacement = formatColours(entry.getValue());
             this.message = this.message.replace(variable, replacement);
         }
+    }
+
+    public void setPerPlayer(boolean perPlayer) {
+        this.perPlayer = perPlayer;
     }
 
     /**

--- a/even-more-fish-paper/src/main/java/com/oheers/fish/adapter/PaperMessage.java
+++ b/even-more-fish-paper/src/main/java/com/oheers/fish/adapter/PaperMessage.java
@@ -68,7 +68,7 @@ public class PaperMessage extends AbstractMessage {
 
         String originalMessage = getRawMessage();
 
-        if (target instanceof Player player) {
+        if (perPlayer && target instanceof Player player) {
             setPlayer(player);
         }
 
@@ -85,7 +85,7 @@ public class PaperMessage extends AbstractMessage {
 
         String originalMessage = getRawMessage();
 
-        if (target instanceof Player player) {
+        if (perPlayer && target instanceof Player player) {
             setPlayer(player);
         }
 

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -38,7 +38,7 @@ repositories {
     maven("https://repo.auxilor.io/repository/maven-public/")
     maven("https://repo.rosewooddev.io/repository/public/")
     maven("https://repo.minebench.de/")
-    maven("https://repo.firedev.uk/repository/maven-public/")
+    maven("https://repo.codemc.io/repository/FireML/")
     maven("https://repo.essentialsx.net/releases/")
     maven("https://repo.aikar.co/content/groups/aikar/")
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/adapter/SpigotMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/adapter/SpigotMessage.java
@@ -49,7 +49,7 @@ public class SpigotMessage extends AbstractMessage {
 
         String originalMessage = getRawMessage();
 
-        if (target instanceof Player player) {
+        if (perPlayer && target instanceof Player player) {
             setPlayer(player);
         }
 
@@ -66,7 +66,7 @@ public class SpigotMessage extends AbstractMessage {
 
         String originalMessage = getRawMessage();
 
-        if (target instanceof Player player) {
+        if (perPlayer && target instanceof Player player) {
             setPlayer(player);
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -235,12 +235,12 @@ public class Competition {
      *
      * @return A boolean, true = do it in actionbar.
      */
-    public boolean isDoingFirstPlaceActionBar() {
+    public static boolean isDoingFirstPlaceActionBar() {
         boolean doActionBarMessage = MessageConfig.getInstance().getConfig().getBoolean("action-bar-message");
-        boolean isSupportedActionBarType = MessageConfig.getInstance().getConfig().getStringList("action-bar-types").isEmpty() || MessageConfig.getInstance()
-                .getConfig()
-                .getStringList("action-bar-types")
-                .contains(getCompetitionType().toString());
+        List<String> supportedTypes = MessageConfig.getInstance()
+            .getConfig()
+            .getStringList("action-bar-types");
+        boolean isSupportedActionBarType = active != null && supportedTypes.contains(active.competitionType.toString());
         return doActionBarMessage && isSupportedActionBarType;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -328,16 +328,12 @@ public class Competition {
             AbstractMessage message = ConfigMessage.LEADERBOARD_LARGEST_FISH.getMessage();
             message.setPlayer(Bukkit.getOfflinePlayer(entry.getPlayer()));
             message.setPosition(Integer.toString(pos));
-
             message.setPositionColour(competitionColours.get(pos - 1));
 
             if (isConsole) {
                 message = competitionType.getStrategy().getSingleConsoleLeaderboardMessage(message, entry);
             } else {
                 message = competitionType.getStrategy().getSinglePlayerLeaderboard(message, entry);
-                if (entry.getPlayer().equals(playerUuid)) {
-                    message.setPositionColour("&f"); // Customize player-specific logic here if needed
-                }
             }
 
             builder.append(message.getLegacyMessage()).append("\n");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -268,7 +268,7 @@ public class Competition {
         }
 
         List<String> competitionColours = competitionFile.getPositionColours();
-        List<CompetitionEntry> entries = getSortedEntries(leaderboard.getEntries());
+        List<CompetitionEntry> entries = leaderboard.getEntries();
 
         String leaderboardMessage = buildLeaderboardMessage(entries, competitionColours, true, null);
         console.sendMessage(leaderboardMessage);
@@ -364,7 +364,7 @@ public class Competition {
         boolean databaseEnabled = MainConfig.getInstance().databaseEnabled();
         int rewardPlace = 1;
 
-        List<CompetitionEntry> entries = getSortedEntries(leaderboard.getEntries());
+        List<CompetitionEntry> entries = leaderboard.getEntries();
 
         if (databaseEnabled && !entries.isEmpty()) {
             handleDatabaseUpdates(entries.get(0), true); // Top entry

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -292,7 +292,7 @@ public class Competition {
         }
 
         List<String> competitionColours = competitionFile.getPositionColours();
-        List<CompetitionEntry> entries = getSortedEntries(leaderboard.getEntries());
+        List<CompetitionEntry> entries = leaderboard.getEntries();
 
         String leaderboardMessage = buildLeaderboardMessage(entries, competitionColours, false, player.getUniqueId());
         player.sendMessage(leaderboardMessage);
@@ -300,13 +300,6 @@ public class Competition {
         AbstractMessage message = ConfigMessage.LEADERBOARD_TOTAL_PLAYERS.getMessage();
         message.setAmount(Integer.toString(leaderboard.getSize()));
         message.send(player);
-    }
-
-    public @NotNull List<CompetitionEntry> getSortedEntries(List<CompetitionEntry> entries) {
-        if (competitionType == CompetitionType.SHORTEST_FISH) {
-            entries.sort(Comparator.comparingDouble(entry -> entry.getFish().getLength()));
-        }
-        return entries;
     }
 
     private @NotNull String buildLeaderboardMessage(List<CompetitionEntry> entries, List<String> competitionColours, boolean isConsole, UUID playerUuid) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
@@ -4,6 +4,7 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.FileUtil;
 import com.oheers.fish.competition.configs.CompetitionConversions;
 import com.oheers.fish.competition.configs.CompetitionFile;
+import org.antlr.runtime.tree.Tree;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,7 +27,7 @@ public class CompetitionQueue {
     }
 
     public Map<Integer, Competition> getCompetitions() {
-        return Map.copyOf(competitions);
+        return new HashMap<>(competitions);
     }
 
     public void load() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
@@ -27,7 +27,7 @@ public class CompetitionQueue {
     }
 
     public Map<Integer, Competition> getCompetitions() {
-        return new HashMap<>(competitions);
+        return competitions;
     }
 
     public void load() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
@@ -2,6 +2,7 @@ package com.oheers.fish.competition.leaderboard;
 
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.api.adapter.AbstractMessage;
+import com.oheers.fish.competition.Competition;
 import com.oheers.fish.competition.CompetitionEntry;
 import com.oheers.fish.competition.CompetitionType;
 import com.oheers.fish.config.messages.ConfigMessage;
@@ -75,7 +76,11 @@ public class Leaderboard implements LeaderboardHandler {
         message.setFishCaught(newFish.getName());
         message.setRarity(newFish.getRarity().getDisplayName());
 
-        message.broadcast();
+        if (Competition.isDoingFirstPlaceActionBar()) {
+            message.broadcastActionBar();
+        } else {
+            message.broadcast();
+        }
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
@@ -1,8 +1,15 @@
 package com.oheers.fish.competition.leaderboard;
 
+import com.oheers.fish.FishUtils;
+import com.oheers.fish.api.adapter.AbstractMessage;
 import com.oheers.fish.competition.CompetitionEntry;
 import com.oheers.fish.competition.CompetitionType;
+import com.oheers.fish.config.messages.ConfigMessage;
 import com.oheers.fish.fishing.items.Fish;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jooq.impl.QOM;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -31,14 +38,44 @@ public class Leaderboard implements LeaderboardHandler {
     }
 
     @Override
-    public void addEntry(UUID player, Fish fish) {
+    public void addEntry(@NotNull UUID player, @NotNull Fish fish) {
         CompetitionEntry entry = new CompetitionEntry(player, fish, type);
-        entries.add(entry);
+        addEntry(entry);
     }
 
     @Override
-    public void addEntry(CompetitionEntry entry) {
+    public void addEntry(@NotNull CompetitionEntry entry) {
+        CompetitionEntry initialTopEntry = getTopEntry();
+
         entries.add(entry);
+
+        CompetitionEntry newTopEntry = getTopEntry();
+
+        // Check for a new first place
+        if (initialTopEntry == null || newTopEntry == null) {
+            return;
+        }
+
+        UUID initialPlayer = initialTopEntry.getPlayer();
+        UUID newPlayer = newTopEntry.getPlayer();
+
+        if (newPlayer.equals(initialPlayer)) {
+            return;
+        }
+
+        Fish newFish = newTopEntry.getFish();
+
+        AbstractMessage message = ConfigMessage.NEW_FIRST_PLACE_NOTIFICATION.getMessage();
+
+        message.setPerPlayer(false);
+
+        message.setPlayer(Bukkit.getOfflinePlayer(newPlayer));
+        message.setLength(Float.toString(newFish.getLength()));
+        message.setRarityColour(newFish.getRarity().getColour());
+        message.setFishCaught(newFish.getName());
+        message.setRarity(newFish.getRarity().getDisplayName());
+
+        message.broadcast();
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/Processor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/Processor.java
@@ -153,7 +153,7 @@ public abstract class Processor<E extends Event> implements Listener {
                 message.setMessage(ConfigMessage.FISH_LENGTHLESS_CAUGHT.getMessage());
             }
 
-            if (fish.getRarity().getAnnounce()) {
+            if (fish.getRarity().getAnnounce() && Competition.isActive()) {
                 FishUtils.broadcastFishMessage(message, player, false);
             } else {
                 message.send(player);

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -70,7 +70,7 @@ dependencyResolutionManagement {
             library("universalscheduler", "com.github.Anon8281:UniversalScheduler:0.1.6")
             library("playerpoints", "org.black_ixx:playerpoints:3.2.7")
 
-            library("vanishchecker", "uk.firedev:VanishChecker:1.0.4")
+            library("vanishchecker", "uk.firedev:VanishChecker:1.0.5")
 
             library("commandapi", "dev.jorel:commandapi-bukkit-shade:9.7.0")
             library("inventorygui", "de.themoep:inventorygui:1.6.4-SNAPSHOT")


### PR DESCRIPTION
## Description
Fixes some issues related to competitions

---

### What has changed?
- The competition new first place message is now shown again.
- Added AbstractMessage#setPerPlayer to prevent incorrect placeholders in some places.
- The competition leaderboard no longer sets the player's own username to white.
- Removed Competition#getSortedEntries as the leaderboard does this for us and it was throwing exceptions.
- Updated my repository URL to the new one.
- FishUtils#broadcastFishMessage is now only called if a competition is active, this fixes the fish caught message when a competition is not active.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.