### PR TITLE
Allow subcommands to be configured

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
@@ -20,28 +20,28 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 public class MainCommand {
-    
+
     private final HelpMessageBuilder helpMessageBuilder = HelpMessageBuilder.create();
 
     private final CommandAPICommand command;
 
     public MainCommand() {
         this.command = new CommandAPICommand(MainConfig.getInstance().getMainCommandName())
-                .withAliases(MainConfig.getInstance().getMainCommandAliases().toArray(String[]::new))
-                .withSubcommands(
-                        getNext(),
-                        getToggle(),
-                        getGui(),
-                        getHelp(),
-                        getTop(),
-                        getShop(),
-                        getSellAll(),
-                        getApplyBaits(),
-                        new AdminCommand("admin").getCommand()
-                )
-                .executes(info -> {
-                    sendHelpMessage(info.sender());
-                });
+            .withAliases(MainConfig.getInstance().getMainCommandAliases().toArray(String[]::new))
+            .withSubcommands(
+                getNext(),
+                getToggle(),
+                getGui(),
+                getHelp(),
+                getTop(),
+                getShop(),
+                getSellAll(),
+                getApplyBaits(),
+                new AdminCommand("admin").getCommand()
+            )
+            .executes(info -> {
+                sendHelpMessage(info.sender());
+            });
     }
 
     public CommandAPICommand getCommand() {
@@ -49,142 +49,150 @@ public class MainCommand {
     }
 
     private CommandAPICommand getNext() {
+        String name = MainConfig.getInstance().getNextSubCommandName();
         helpMessageBuilder.addUsage(
-                "next", 
-                ConfigMessage.HELP_GENERAL_NEXT::getMessage
+            name,
+            ConfigMessage.HELP_GENERAL_NEXT::getMessage
         );
-        return new CommandAPICommand("next")
-                .withPermission(UserPerms.NEXT)
-                .executes(info -> {
-                    EMFMessage message = Competition.getNextCompetitionMessage();
-                    message.prependMessage(PrefixType.DEFAULT.getPrefix());
-                    message.send(info.sender());
-                });
+        return new CommandAPICommand(name)
+            .withPermission(UserPerms.NEXT)
+            .executes(info -> {
+                EMFMessage message = Competition.getNextCompetitionMessage();
+                message.prependMessage(PrefixType.DEFAULT.getPrefix());
+                message.send(info.sender());
+            });
     }
 
     private CommandAPICommand getToggle() {
+        String name = MainConfig.getInstance().getToggleSubCommandName();
         helpMessageBuilder.addUsage(
-                "toggle",
-                ConfigMessage.HELP_GENERAL_TOGGLE::getMessage
+            name,
+            ConfigMessage.HELP_GENERAL_TOGGLE::getMessage
         );
-        return new CommandAPICommand("toggle")
-                .withPermission(UserPerms.TOGGLE)
-                .executesPlayer(info -> {
-                    EvenMoreFish.getInstance().performFishToggle(info.sender());
-                });
+        return new CommandAPICommand(name)
+            .withPermission(UserPerms.TOGGLE)
+            .executesPlayer(info -> {
+                EvenMoreFish.getInstance().performFishToggle(info.sender());
+            });
     }
 
     private CommandAPICommand getGui() {
+        String name = MainConfig.getInstance().getGuiSubCommandName();
         helpMessageBuilder.addUsage(
-                "gui",
-                ConfigMessage.HELP_GENERAL_GUI::getMessage
+            name,
+            ConfigMessage.HELP_GENERAL_GUI::getMessage
         );
-        return new CommandAPICommand("gui")
-                .withPermission(UserPerms.GUI)
-                .executesPlayer(info -> {
-                    new MainMenuGui(info.sender()).open();
-                });
+        return new CommandAPICommand(name)
+            .withPermission(UserPerms.GUI)
+            .executesPlayer(info -> {
+                new MainMenuGui(info.sender()).open();
+            });
     }
 
     private CommandAPICommand getHelp() {
+        String name = MainConfig.getInstance().getHelpSubCommandName();
         helpMessageBuilder.addUsage(
-                "help",
-                ConfigMessage.HELP_GENERAL_HELP::getMessage
+            name,
+            ConfigMessage.HELP_GENERAL_HELP::getMessage
         );
-        return new CommandAPICommand("help")
-                .withPermission(UserPerms.HELP)
-                .executes(info -> {
-                    sendHelpMessage(info.sender());
-                });
+        return new CommandAPICommand(name)
+            .withPermission(UserPerms.HELP)
+            .executes(info -> {
+                sendHelpMessage(info.sender());
+            });
     }
 
     private CommandAPICommand getTop() {
+        String name = MainConfig.getInstance().getTopSubCommandName();
         helpMessageBuilder.addUsage(
-                "top",
-                ConfigMessage.HELP_GENERAL_TOP::getMessage
+            name,
+            ConfigMessage.HELP_GENERAL_TOP::getMessage
         );
-        return new CommandAPICommand("top")
-                .withPermission(UserPerms.TOP)
-                .executesPlayer(info -> {
-                    Competition active = Competition.getCurrentlyActive();
-                    if (active == null) {
-                        ConfigMessage.NO_COMPETITION_RUNNING.getMessage().send(info.sender());
-                        return;
-                    }
-                    active.sendPlayerLeaderboard(info.sender());
-                })
-                .executes(info -> {
-                    Competition active = Competition.getCurrentlyActive();
-                    if (active == null) {
-                        ConfigMessage.NO_COMPETITION_RUNNING.getMessage().send(info.sender());
-                        return;
-                    }
-                    active.sendConsoleLeaderboard(info.sender());
-                });
+        return new CommandAPICommand(name)
+            .withPermission(UserPerms.TOP)
+            .executesPlayer(info -> {
+                Competition active = Competition.getCurrentlyActive();
+                if (active == null) {
+                    ConfigMessage.NO_COMPETITION_RUNNING.getMessage().send(info.sender());
+                    return;
+                }
+                active.sendPlayerLeaderboard(info.sender());
+            })
+            .executes(info -> {
+                Competition active = Competition.getCurrentlyActive();
+                if (active == null) {
+                    ConfigMessage.NO_COMPETITION_RUNNING.getMessage().send(info.sender());
+                    return;
+                }
+                active.sendConsoleLeaderboard(info.sender());
+            });
     }
 
     private CommandAPICommand getShop() {
+        String name = MainConfig.getInstance().getShopSubCommandName();
         helpMessageBuilder.addUsage(
-                "shop",
-                ConfigMessage.HELP_GENERAL_SHOP::getMessage
+            name,
+            ConfigMessage.HELP_GENERAL_SHOP::getMessage
         );
-        return new CommandAPICommand("shop")
-                .withPermission(UserPerms.SHOP)
-                .withArguments(
-                        ArgumentHelper.getPlayerArgument("target").setOptional(true)
-                )
-                .executes((sender, args) -> {
-                    Player player = args.getUnchecked("target");
-                    if (player == null){
-                        if (!(sender instanceof Player p)) {
-                            ConfigMessage.ADMIN_CANT_BE_CONSOLE.getMessage().send(sender);
-                            return;
-                        }
-                        player = p;
-                    }
-                    if (!checkEconomy(player)) {
+        return new CommandAPICommand(name)
+            .withPermission(UserPerms.SHOP)
+            .withArguments(
+                ArgumentHelper.getPlayerArgument("target").setOptional(true)
+            )
+            .executes((sender, args) -> {
+                Player player = args.getUnchecked("target");
+                if (player == null) {
+                    if (!(sender instanceof Player p)) {
+                        ConfigMessage.ADMIN_CANT_BE_CONSOLE.getMessage().send(sender);
                         return;
                     }
-                    if (sender == player) {
-                        new SellGui(player, SellGui.SellState.NORMAL, null).open();
-                        return;
-                    }
-                    if (!sender.hasPermission(AdminPerms.ADMIN)) {
-                        ConfigMessage.NO_PERMISSION.getMessage().send(sender);
-                        return;
-                    }
+                    player = p;
+                }
+                if (!checkEconomy(player)) {
+                    return;
+                }
+                if (sender == player) {
                     new SellGui(player, SellGui.SellState.NORMAL, null).open();
-                    EMFMessage message = ConfigMessage.ADMIN_OPEN_FISH_SHOP.getMessage();
-                    message.setPlayer(player);
-                    message.send(sender);
-                });
+                    return;
+                }
+                if (!sender.hasPermission(AdminPerms.ADMIN)) {
+                    ConfigMessage.NO_PERMISSION.getMessage().send(sender);
+                    return;
+                }
+                new SellGui(player, SellGui.SellState.NORMAL, null).open();
+                EMFMessage message = ConfigMessage.ADMIN_OPEN_FISH_SHOP.getMessage();
+                message.setPlayer(player);
+                message.send(sender);
+            });
     }
 
     private CommandAPICommand getSellAll() {
+        String name = MainConfig.getInstance().getSellAllSubCommandName();
         helpMessageBuilder.addUsage(
-                "sellall",
-                ConfigMessage.HELP_GENERAL_SELLALL::getMessage
+            name,
+            ConfigMessage.HELP_GENERAL_SELLALL::getMessage
         );
-        return new CommandAPICommand("sellall")
-                .withPermission(UserPerms.SELL_ALL)
-                .executesPlayer(info -> {
-                    Player player = info.sender();
-                    if (checkEconomy(player)) {
-                        new SellHelper(player.getInventory(), player).sellFish();
-                    }
-                });
+        return new CommandAPICommand(name)
+            .withPermission(UserPerms.SELL_ALL)
+            .executesPlayer(info -> {
+                Player player = info.sender();
+                if (checkEconomy(player)) {
+                    new SellHelper(player.getInventory(), player).sellFish();
+                }
+            });
     }
 
     private CommandAPICommand getApplyBaits() {
+        String name = MainConfig.getInstance().getApplyBaitsSubCommandName();
         helpMessageBuilder.addUsage(
-                "applybaits",
-                ConfigMessage.HELP_GENERAL_APPLYBAITS::getMessage
+            name,
+            ConfigMessage.HELP_GENERAL_APPLYBAITS::getMessage
         );
-        return new CommandAPICommand("applybaits")
-                .withPermission(UserPerms.APPLYBAITS)
-                .executesPlayer(info -> {
-                    new ApplyBaitsGui(info.sender(), null).open();
-                });
+        return new CommandAPICommand(name)
+            .withPermission(UserPerms.APPLYBAITS)
+            .executesPlayer(info -> {
+                new ApplyBaitsGui(info.sender(), null).open();
+            });
     }
 
     private void sendHelpMessage(@NotNull CommandSender sender) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
@@ -26,6 +26,13 @@ public class MainCommand {
     private final CommandAPICommand command;
 
     public MainCommand() {
+        // Add the admin command to the help message
+        String adminName = MainConfig.getInstance().getAdminSubCommandName();
+        helpMessageBuilder.addUsage(
+            adminName,
+            ConfigMessage.HELP_GENERAL_ADMIN::getMessage
+        );
+
         this.command = new CommandAPICommand(MainConfig.getInstance().getMainCommandName())
             .withAliases(MainConfig.getInstance().getMainCommandAliases().toArray(String[]::new))
             .withSubcommands(
@@ -37,7 +44,7 @@ public class MainCommand {
                 getShop(),
                 getSellAll(),
                 getApplyBaits(),
-                new AdminCommand(MainConfig.getInstance().getAdminSubCommandName()).getCommand()
+                new AdminCommand(adminName).getCommand()
             )
             .executes(info -> {
                 sendHelpMessage(info.sender());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
@@ -37,7 +37,7 @@ public class MainCommand {
                 getShop(),
                 getSellAll(),
                 getApplyBaits(),
-                new AdminCommand("admin").getCommand()
+                new AdminCommand(MainConfig.getInstance().getAdminSubCommandName()).getCommand()
             )
             .executes(info -> {
                 sendHelpMessage(info.sender());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -19,13 +19,39 @@ public class MainConfig extends ConfigBase {
     private static MainConfig instance = null;
 
     // Cache these so we don't have a mismatch after reload.
-    private String mainCommandName = null;
-    private List<String> mainCommandAliases = null;
+    private final boolean adminShortcutEnabled;
+    private final String adminShortcutName;
+    private final String mainCommandName;
+    private final List<String> mainCommandAliases;
+    private final String adminSubCommandName;
+    private final String nextSubCommandName;
+    private final String toggleSubCommandName;
+    private final String guiSubCommandName;
+    private final String helpSubCommandName;
+    private final String topSubCommandName;
+    private final String shopSubCommandName;
+    private final String sellAllSubCommandName;
+    private final String applyBaitsSubCommandName;
 
     public MainConfig() {
         super("config.yml", "config.yml", EvenMoreFish.getInstance(), true);
         instance = this;
         applyOneTimeConversions();
+
+        // Command caching
+        this.mainCommandName = getConfig().getString("command.main", "emf");
+        this.mainCommandAliases = getConfig().getStringList("command.aliases");
+        this.adminShortcutEnabled = getConfig().getBoolean("command.admin-shortcut.enabled", true);
+        this.adminShortcutName = getConfig().getString("command.admin-shortcut.name", "emfa");
+        this.adminSubCommandName = getConfig().getString("command.subcommands.admin", "admin");
+        this.nextSubCommandName = getConfig().getString("command.subcommands.next", "next");
+        this.toggleSubCommandName = getConfig().getString("command.subcommands.toggle", "toggle");
+        this.guiSubCommandName = getConfig().getString("command.subcommands.gui", "gui");
+        this.helpSubCommandName = getConfig().getString("command.subcommands.help", "help");
+        this.topSubCommandName = getConfig().getString("command.subcommands.top", "top");
+        this.shopSubCommandName = getConfig().getString("command.subcommands.shop", "shop");
+        this.sellAllSubCommandName = getConfig().getString("command.subcommands.sellall", "sellall");
+        this.applyBaitsSubCommandName = getConfig().getString("command.subcommands.apply-baits", "applybaits");
     }
 
     public static MainConfig getInstance() {
@@ -198,25 +224,55 @@ public class MainConfig extends ConfigBase {
     public int getNearbyPlayersRequirementRange() { return getConfig().getInt("requirements.nearby-players.range", 0); }
 
     public boolean isAdminShortcutCommandEnabled() {
-        return getConfig().getBoolean("command.admin-shortcut.enabled", true);
+        return adminShortcutEnabled;
     }
 
     public String getAdminShortcutCommandName() {
-        return getConfig().getString("command.admin-shortcut.name", "emfa");
+        return adminShortcutName;
     }
 
     public String getMainCommandName() {
-        if (mainCommandName == null) {
-            mainCommandName = getConfig().getString("command.main", "emf");
-        }
         return mainCommandName;
     }
 
     public List<String> getMainCommandAliases() {
-        if (mainCommandAliases == null) {
-            mainCommandAliases = getConfig().getStringList("command.aliases");
-        }
         return mainCommandAliases;
+    }
+
+    public String getAdminSubCommandName() {
+        return adminSubCommandName;
+    }
+
+    public String getNextSubCommandName() {
+        return nextSubCommandName;
+    }
+
+    public String getToggleSubCommandName() {
+        return toggleSubCommandName;
+    }
+
+    public String getGuiSubCommandName() {
+        return guiSubCommandName;
+    }
+
+    public String getHelpSubCommandName() {
+        return helpSubCommandName;
+    }
+
+    public String getTopSubCommandName() {
+        return topSubCommandName;
+    }
+
+    public String getShopSubCommandName() {
+        return shopSubCommandName;
+    }
+
+    public String getSellAllSubCommandName() {
+        return sellAllSubCommandName;
+    }
+
+    public String getApplyBaitsSubCommandName() {
+        return applyBaitsSubCommandName;
     }
 
     public boolean giveStraightToInventory() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -51,7 +51,7 @@ public class MainConfig extends ConfigBase {
         this.topSubCommandName = getConfig().getString("command.subcommands.top", "top");
         this.shopSubCommandName = getConfig().getString("command.subcommands.shop", "shop");
         this.sellAllSubCommandName = getConfig().getString("command.subcommands.sellall", "sellall");
-        this.applyBaitsSubCommandName = getConfig().getString("command.subcommands.apply-baits", "applybaits");
+        this.applyBaitsSubCommandName = getConfig().getString("command.subcommands.applybaits", "applybaits");
     }
 
     public static MainConfig getInstance() {

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -193,6 +193,7 @@ requirements:
 give-straight-to-inventory: false
 
 # Customize the plugin's command. Requires a server restart to take effect.
+# NOTE: All names and aliases must use English letters only, as the command library does not support other characters.
 command:
   # The /emf admin shortcut command
   admin-shortcut:

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -204,6 +204,27 @@ command:
   aliases:
     - evenmorefish
 
+  # Change the name of the plugin's subcommands
+  subcommands:
+    # The /emf admin command
+    admin: "admin"
+    # The /emf next command
+    next: "next"
+    # The /emf toggle command
+    toggle: "toggle"
+    # The /emf gui command
+    gui: "gui"
+    # The /emf help command
+    help: "help"
+    # The /emf top command
+    top: "top"
+    # The /emf shop command
+    shop: "shop"
+    # The /emf sellall command
+    sellall: "sellall"
+    # The /emf applybaits command
+    applybaits: "applybaits"
+
 # Customizable sets of biomes for fish.yml configuration
 biome-sets:
   # oceans biome set. you can add more sets as you please.
@@ -218,4 +239,4 @@ biome-sets:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 23
+config-version: 24


### PR DESCRIPTION
## Description
Allows player-facing subcommands to be configured.

---

### What has changed?
- Added configurations for player-facing subcommand names to config.yml
- Updated MainCommand to use these configured names
- Added a note to the config about Brigadier's limitations
- The /emfa alias config is now cached as intended

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.