### PR TITLE
Adds the ability to disable catching specific baits

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
@@ -303,4 +303,9 @@ public class Bait extends ConfigBase {
     public String getDisplayName() {
         return getConfig().getString("item.displayname", this.id);
     }
+
+    public boolean getCanBeCaught() {
+        return getConfig().getBoolean("can-be-caught", true);
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -266,8 +266,10 @@ public class BaitNBTManager {
     public static @Nullable Bait randomBaitCatch() {
 
         Map<String, Bait> baitMap = BaitManager.getInstance().getBaitMap();
-        List<Bait> baitList = new ArrayList<>(baitMap.values());
-
+        List<Bait> baitList = baitMap.values().stream()
+            .filter(Bait::getCanBeCaught)
+            .toList();
+        
         // Fix IndexOutOfBoundsException caused by the list being empty.
         if (baitList.isEmpty()) {
             return null;

--- a/even-more-fish-plugin/src/main/resources/baits/_example.yml
+++ b/even-more-fish-plugin/src/main/resources/baits/_example.yml
@@ -14,6 +14,9 @@ bait-theme: "<yellow>"
 # When more than 1 types of baits are applied, how likely is it that this one should be used?
 application-weight: 150
 
+# Can this bait be caught by fishing?
+can-be-caught: true
+
 # How likely should it be to find this bait when they're caught.
 catch-weight: 100
 


### PR DESCRIPTION
## Description
Adds the ability to disable catching specific baits

---

### What has changed?
- Bait configs can now take a `can-be-caught` value to determine whether it should be caught by fishing.

---

### Related Issues
Requested on Discord.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.