### PR TITLE
Possible ItemAddon fix

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/addons/AddonManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/addons/AddonManager.java
@@ -44,7 +44,6 @@ public class AddonManager {
 
     @Nullable
     public ItemStack getItemStack(final String prefix, final String id) throws NoPrefixException {
-        // somehow, oraxen isn't registered as loaded
         if (!addonMap.containsKey(prefix)) {
             if (!loadingMap.getOrDefault(prefix, true)) {
                 throw new NoPrefixException(prefix);
@@ -54,7 +53,7 @@ public class AddonManager {
 
         final Addon addon = addonMap.get(prefix);
         if (!(addon instanceof ItemAddon itemAddon)) {
-            return new ItemStack(Material.AIR);
+            return null;
         }
         return itemAddon.getItemStack(id);
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -143,26 +143,21 @@ public class Fish {
      * @return An ItemStack version of the fish.
      */
     public ItemStack give(int randomIndex) {
-
         ItemStack fish = factory.createItem(getFishermanPlayer(), randomIndex);
-        if (factory.isRawMaterial()) return fish;
-        ItemMeta fishMeta = fish.getItemMeta();
-
-        if (fishMeta != null) {
-            NBT.modify(fish, nbt -> {
-                nbt.modifyMeta((readOnlyNbt, meta) -> {
-                    meta.displayName(getDisplayName().getComponentMessage());
-                    if (!section.getBoolean("disable-lore", false)) {
-                        meta.lore(getFishLore());
-                    }
-                    meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
-                    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-                    meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-                });
-            });
-
-            WorthNBT.setNBT(fish, this);
+        if (factory.isRawMaterial()) {
+            return fish;
         }
+
+        fish.editMeta(meta -> {
+            meta.displayName(getDisplayName().getComponentMessage());
+            if (!section.getBoolean("disable-lore", false)) {
+                meta.lore(getFishLore());
+            }
+            meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+        });
+        WorthNBT.setNBT(fish, this);
 
         return fish;
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -459,7 +459,6 @@ public class ItemFactory {
         itemRandom = true;
 
         return EvenMoreFish.getInstance().getHDBapi().getItemHead(Integer.toString(headID));
-
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes a potential issue in AddonManager#getItemStack

---

### What has changed?
- AddonManager#getItemStack now returns null instead of air if the Addon is not an ItemAddon

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.