### PR TITLE
Add maven repository information to the wiki

### DIFF
--- a/wiki/Developers.md
+++ b/wiki/Developers.md
@@ -4,5 +4,46 @@ even-more-fish-api & even-more-fish-plugin
 
 In the future these will be further abstracted so you don't need to use the "core" artifact any longer.
 
-## Jitpack.io
-You can find the exact instructions for your build system by clicking on the badge: [![](https://jitpack.io/v/Oheers/EvenMoreFish.svg)](https://jitpack.io/#Oheers/EvenMoreFish)
+## CodeMC
+The plugin is available via CodeMC's Maven Repository. To add it to your build tool, follow the examples below:
+
+### Gradle (Kotlin)
+```kotlin
+repositories {
+    maven("https://repo.codemc.io/repository/EvenMoreFish/")
+}
+
+dependencies {
+    // For the plugin artifact
+    compileOnly("com.oheers.evenmorefish:even-more-fish-plugin:2.0.0-SNAPSHOT")
+    // For the api artifact
+    compileOnly("com.oheers.evenmorefish:even-more-fish-api:2.0.0-SNAPSHOT")
+}
+```
+
+### Maven
+```xml
+<repositories>
+    <repository>
+        <id>evenmorefish</id>
+        <url>https://repo.codemc.io/repository/EvenMoreFish</url>
+    </repository>
+</repositories>
+
+<dependencies>
+    <!-- For the plugin artifact -->
+    <dependency>
+        <groupId>com.oheers.evenmorefish</groupId>
+        <artifactId>even-more-fish-plugin</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <scope>provided</scope>
+    </dependency>
+    <!-- For the api artifact -->
+    <dependency>
+        <groupId>com.oheers.evenmorefish</groupId>
+        <artifactId>even-more-fish-api</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <scope>provided</scope>
+    </dependency>
+</dependencies>
+```


### PR DESCRIPTION
## Description
Adds maven repository information to the wiki

---

### What has changed?
- Developers.md no longer points to Jitpack and instead has instructions for our CodeMC repository

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.