### PR TITLE
Fix italics in EMFListMessage

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -5,6 +5,7 @@ import com.oheers.fish.api.requirement.Requirement;
 import com.oheers.fish.api.reward.Reward;
 import com.oheers.fish.exceptions.InvalidFishException;
 import com.oheers.fish.messages.ConfigMessage;
+import com.oheers.fish.messages.EMFListMessage;
 import com.oheers.fish.messages.EMFSingleMessage;
 import com.oheers.fish.messages.abstracted.EMFMessage;
 import com.oheers.fish.selling.WorthNBT;
@@ -313,7 +314,7 @@ public class Fish {
         List<String> loreOverride = section.getStringList("lore-override");
         EMFMessage newLoreLine;
         if (!loreOverride.isEmpty()) {
-            newLoreLine = EMFSingleMessage.fromStringList(loreOverride);
+            newLoreLine = EMFListMessage.fromStringList(loreOverride);
         } else {
             newLoreLine = ConfigMessage.FISH_LORE.getMessage();
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -77,14 +77,13 @@ public class EMFListMessage extends EMFMessage {
 
     @Override
     public @NotNull Component getComponentMessage() {
-        formatPlaceholderAPI();
-        return Component.join(JoinConfiguration.newlines(), this.message);
+        return Component.join(JoinConfiguration.newlines(), getComponentListMessage());
     }
 
     @Override
     public @NotNull List<Component> getComponentListMessage() {
         formatPlaceholderAPI();
-        return List.copyOf(this.message);
+        return this.message.stream().map(EMFMessage::removeDefaultItalics).toList();
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemBuilder.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemBuilder.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.utils;
 
+import com.oheers.fish.messages.EMFListMessage;
 import com.oheers.fish.messages.EMFSingleMessage;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -69,7 +70,7 @@ public class ItemBuilder {
                 meta.displayName(EMFSingleMessage.fromString(this.display).getComponentMessage());
             }
             if (!this.lore.isEmpty()) {
-                meta.lore(EMFSingleMessage.fromStringList(this.lore).getComponentListMessage());
+                meta.lore(EMFListMessage.fromStringList(this.lore).getComponentListMessage());
             }
         });
         if (this.glowing) {


### PR DESCRIPTION
## Description
Fixes italics in EMFListMessage

---

### What has changed?
- Default italics are now removed in EMFListMessage
- Fixed some more usages of EMFSingleMessage where EMFListMessage was supposed to be used

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.