### PR TITLE
Fix empty lines in fish lore

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,3 @@ Link related issues or describe which problem this PR fixes.
 
 - [ ] I have added tests that prove my fix is effective or that my feature works.
 - [ ] I have updated the documentation as needed.
-- [ ] I have added any labels that fit this PR.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -363,7 +363,7 @@ public class AdminCommand {
                 EMFSingleMessage message = EMFSingleMessage.fromString(msgString);
 
                 message.setVariable("{prefix}", MessageConfig.getInstance().getSTDPrefix());
-                message.setVariable("{version}", EvenMoreFish.getInstance().getDescription().getVersion());
+                message.setVariable("{version}", EvenMoreFish.getInstance().getPluginMeta().getVersion());
                 message.setVariable("{branch}", getFeatureBranchName());
                 message.setVariable("{build-date}", getFeatureBranchBuildOrDate());
                 message.setVariable("{mcv}", Bukkit.getServer().getVersion());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -11,9 +11,7 @@ import com.oheers.fish.messages.abstracted.EMFMessage;
 import com.oheers.fish.selling.WorthNBT;
 import com.oheers.fish.utils.ItemFactory;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
-import jdk.jfr.Experimental;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -312,12 +310,7 @@ public class Fish {
      *
      * @return A lore to be used by fetching data from the old messages.yml set-up.
      */
-    /**
-     * Gets the formatted lore for the fish item, handling newlines and empty placeholders properly.
-     * @return A list of MiniMessage components for the item lore
-     */
     private List<Component> getFishLore() {
-        // Get the lore format (either from override or default config)
         List<String> loreOverride = section.getStringList("lore-override");
         EMFMessage newLoreLine;
         if (!loreOverride.isEmpty()) {
@@ -326,14 +319,12 @@ public class Fish {
             newLoreLine = ConfigMessage.FISH_LORE.getMessage();
         }
 
-        // Prepare the fish lore content
         List<String> fishLore = section.getStringList("lore");
         String replacement = fishLore.isEmpty() ? "" : String.join("\n", fishLore);
 
-        // Set {EMPTY} marker for empty fish lore
         newLoreLine.setVariable(
                 "{fish_lore}",
-                replacement.isEmpty() ? "{EMPTY}" : replacement
+                replacement
         );
 
         newLoreLine.setVariable("{fisherman_lore}",
@@ -350,41 +341,17 @@ public class Fish {
                         : ""
         );
 
-        if (length > 0) {
-            newLoreLine.setLength(Float.toString(length));
-        }
+        if (length > 0) newLoreLine.setLength(Float.toString(length));
 
         newLoreLine.setRarity(this.rarity.getLorePrep());
 
-        // Process PlaceholderAPI if available
         OfflinePlayer fisherman = getFishermanPlayer();
         if (fisherman != null) {
             newLoreLine.setPlayer(fisherman);
             newLoreLine.formatPlaceholderAPI();
         }
 
-        // Process the final lore output
-        List<Component> finalLore = new ArrayList<>();
-        for (Component component : newLoreLine.getComponentListMessage()) {
-            String serialized = MiniMessage.miniMessage().serialize(component);
-
-            // TODO: Rework EMFMessage#setVariable to accept a boolean indicating if the line contains the variable. If the replacement message is empty, remove the entire line instead of just the variable.
-            // Check if the serialized string contains the {EMPTY} marker
-            if (serialized.contains("{EMPTY}")) {
-                continue;
-            }
-
-            // Split by newlines and create separate components
-            String[] lines = serialized.split("\n");
-            for (String line : lines) {
-                line = line.trim();
-                if (!line.isEmpty()) {
-                    finalLore.add(MiniMessage.miniMessage().deserialize(line));
-                }
-            }
-        }
-
-        return finalLore;
+        return newLoreLine.getComponentListMessage();
     }
 
     public void checkDisplayName() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -320,28 +320,22 @@ public class Fish {
         }
 
         List<String> fishLore = section.getStringList("lore");
-        String replacement = fishLore.isEmpty() ? "" : String.join("\n", fishLore);
+        EMFListMessage fishLoreReplacement = fishLore.isEmpty() ? EMFListMessage.empty() : EMFListMessage.fromStringList(fishLore);
+        newLoreLine.setVariable("{fish_lore}", fishLoreReplacement);
 
-        newLoreLine.setVariable(
-                "{fish_lore}",
-                replacement
-        );
+        if (!disableFisherman && getFishermanPlayer() != null) {
+            newLoreLine.setVariable("{fisherman_lore}", ConfigMessage.FISHERMAN_LORE.getMessage().toListMessage());
+            newLoreLine.setPlayer(getFishermanPlayer());
+        } else {
+            newLoreLine.setVariable("{fisherman_lore}", EMFListMessage.empty());
+        }
 
-        newLoreLine.setVariable("{fisherman_lore}",
-                !disableFisherman && getFishermanPlayer() != null ?
-                        (ConfigMessage.FISHERMAN_LORE.getMessage())
-                        : ""
-        );
-
-        if (!disableFisherman && getFishermanPlayer() != null) newLoreLine.setPlayer(getFishermanPlayer());
-
-        newLoreLine.setVariable("{length_lore}",
-                length > 0 ?
-                        ConfigMessage.LENGTH_LORE.getMessage()
-                        : ""
-        );
-
-        if (length > 0) newLoreLine.setLength(Float.toString(length));
+        if (length > 0) {
+            newLoreLine.setVariable("{length_lore}", ConfigMessage.LENGTH_LORE.getMessage().toListMessage());
+            newLoreLine.setLength(Float.toString(length));
+        } else {
+            newLoreLine.setVariable("{length_lore}", EMFListMessage.empty());
+        }
 
         newLoreLine.setRarity(this.rarity.getLorePrep());
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -153,7 +153,7 @@ public class Fish {
             if (!section.getBoolean("disable-lore", false)) {
                 meta.lore(getFishLore());
             }
-            meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+            meta.addItemFlags(ItemFlag.HIDE_ITEM_SPECIFICS);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
         });

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/ConfigMessage.java
@@ -315,7 +315,8 @@ public enum ConfigMessage {
     }
 
     public boolean isListForm() {
-        return !MessageConfig.getInstance().getConfig().getStringList(getId()).isEmpty();
+        List<String> strings = MessageConfig.getInstance().getConfig().getStringList(getId());
+        return normalList != null || !strings.isEmpty();
     }
 
     public PrefixType getPrefixType() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -31,9 +31,7 @@ public class EMFListMessage extends EMFMessage {
 
     @Override
     public EMFListMessage createCopy() {
-        EMFListMessage copy = new EMFListMessage(List.copyOf(message));
-        copy.liveVariables.putAll(this.liveVariables);
-        return copy;
+        return toListMessage();
     }
 
     // Factory methods

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -160,7 +160,7 @@ public class EMFListMessage extends EMFMessage {
         if (replacement instanceof EMFSingleMessage singleMessage) {
             setComponentVariable(variable, singleMessage.getComponentMessage());
         } else if (replacement instanceof EMFListMessage listMessage) {
-            this.message = formatListVariable(variable, listMessage);
+            formatListVariable(variable, listMessage);
         }
     }
 
@@ -178,8 +178,8 @@ public class EMFListMessage extends EMFMessage {
             .collect(Collectors.toCollection(ArrayList::new));
     }
 
-    private ArrayList<Component> formatListVariable(@NotNull String variable, @NotNull EMFListMessage replacement) {
-        return this.message.stream()
+    private void formatListVariable(@NotNull String variable, @NotNull EMFListMessage replacement) {
+        this.message = this.message.stream()
             .flatMap(line -> {
                 // If the replacement is empty, return an empty stream to remove the line
                 if (replacement.isEmpty()) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -181,12 +181,12 @@ public class EMFListMessage extends EMFMessage {
     private void formatListVariable(@NotNull String variable, @NotNull EMFListMessage replacement) {
         this.message = this.message.stream()
             .flatMap(line -> {
-                // If the replacement is empty, return an empty stream to remove the line
-                if (replacement.isEmpty()) {
-                    return Stream.empty();
-                }
                 // If the variable is present in the line, replace it
                 if (FishUtils.componentContainsString(line, variable)) {
+                    // If the replacement is empty, return an empty stream to remove the line
+                    if (replacement.isEmpty()) {
+                        return Stream.empty();
+                    }
                     return replacement.getComponentListMessage().stream();
                 // If not, return the original line
                 } else {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
@@ -29,9 +29,7 @@ public class EMFSingleMessage extends EMFMessage {
 
     @Override
     public EMFSingleMessage createCopy() {
-        EMFSingleMessage copy = new EMFSingleMessage(this.message);
-        copy.liveVariables.putAll(this.liveVariables);
-        return copy;
+        return toSingleMessage();
     }
 
     // Factory methods

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/PrefixType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/PrefixType.java
@@ -32,9 +32,7 @@ public enum PrefixType {
         if (id == null) {
             return EMFSingleMessage.empty();
         } else {
-            EMFSingleMessage message = EMFSingleMessage.fromString(MessageConfig.getInstance().getConfig().getString(id, normal));
-            message.appendString("<reset>");
-            return message;
+            return EMFSingleMessage.fromString(MessageConfig.getInstance().getConfig().getString(id, normal));
         }
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
@@ -1,6 +1,8 @@
 package com.oheers.fish.messages.abstracted;
 
 import com.oheers.fish.FishUtils;
+import com.oheers.fish.messages.EMFListMessage;
+import com.oheers.fish.messages.EMFSingleMessage;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -25,7 +27,6 @@ public abstract class EMFMessage {
     public static final PlainTextComponentSerializer PLAINTEXT_SERIALIZER = PlainTextComponentSerializer.plainText();
     public static final Component EMPTY = Component.empty().colorIfAbsent(NamedTextColor.WHITE);
 
-    protected final Map<String, List<Component>> liveVariables = new LinkedHashMap<>();
 
     protected boolean perPlayer = true;
     protected boolean canSilent = false;
@@ -431,6 +432,24 @@ public abstract class EMFMessage {
      */
     public void setMaxBaits(@NotNull final Object maxBaits) {
         setVariable("{max_baits}", maxBaits);
+    }
+
+    // Subclass things
+
+    public EMFSingleMessage toSingleMessage() {
+        EMFSingleMessage message = EMFSingleMessage.of(getComponentMessage());
+        message.perPlayer = this.perPlayer;
+        message.canSilent = this.canSilent;
+        message.relevantPlayer = this.relevantPlayer;
+        return message;
+    }
+
+    public EMFListMessage toListMessage() {
+        EMFListMessage message = EMFListMessage.ofList(getComponentListMessage());
+        message.perPlayer = this.perPlayer;
+        message.canSilent = this.canSilent;
+        message.relevantPlayer = this.relevantPlayer;
+        return message;
     }
 
 }


### PR DESCRIPTION
## Description
Fixes an issue where fish lore variables would be replaced with nothing and leave an empty line.

---

### What has changed?
- ConfigMessage#isListForm now checks if the default is a list OR if it's configured as a list
- EMFListMessage now replaces whole lines if they contain a variable and the replacement is another EMFListMessage
- Added EMFMessage#toSingleMessage
- Added EMFMessage#toListMessage
- Resolved some leftover deprecations

- Removed the "I have added any labels that fit this PR." checkbox in the PR template as contributors can't add them

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.