### PR TITLE
Fix variable in the MOST_FISH leaderboard

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/LargestFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/LargestFishStrategy.java
@@ -31,23 +31,15 @@ public class LargestFishStrategy implements CompetitionStrategy {
 
     @Override
     public EMFMessage getSingleConsoleLeaderboardMessage(@NotNull CompetitionEntry entry) {
-        Fish fish = entry.getFish();
-
         EMFMessage message = ConfigMessage.LEADERBOARD_LARGEST_FISH.getMessage();
         message.setLength(getDecimalFormat().format(entry.getValue()));
-        message.setRarity(fish.getRarity().getDisplayName());
-        message.setFishCaught(fish.getDisplayName());
         return message;
     }
 
     @Override
     public EMFMessage getSinglePlayerLeaderboard(@NotNull CompetitionEntry entry) {
-        Fish fish = entry.getFish();
-
         EMFMessage message = ConfigMessage.LEADERBOARD_LARGEST_FISH.getMessage();
         message.setLength(getDecimalFormat().format(entry.getValue()));
-        message.setRarity(fish.getRarity().getDisplayName());
-        message.setFishCaught(fish.getDisplayName());
         return message;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/MostFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/MostFishStrategy.java
@@ -35,7 +35,7 @@ public class MostFishStrategy implements CompetitionStrategy {
     @Override
     public EMFMessage getSingleConsoleLeaderboardMessage(@NotNull CompetitionEntry entry) {
         EMFMessage message = ConfigMessage.LEADERBOARD_MOST_FISH.getMessage();
-        message.setLength(getDecimalFormat().format(entry.getValue()));
+        message.setAmount(getDecimalFormat().format(entry.getValue()));
         return message;
     }
 
@@ -48,7 +48,8 @@ public class MostFishStrategy implements CompetitionStrategy {
     @Override
     public EMFMessage getSinglePlayerLeaderboard(@NotNull CompetitionEntry entry) {
         EMFMessage message = ConfigMessage.LEADERBOARD_MOST_FISH.getMessage();
-        message.setLength(getDecimalFormat().format(entry.getValue()));
+        message.setAmount(getDecimalFormat().format(entry.getValue()));
         return message;
     }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/ShortestFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/ShortestFishStrategy.java
@@ -31,12 +31,8 @@ public class ShortestFishStrategy implements CompetitionStrategy {
 
     @Override
     public EMFMessage getSingleConsoleLeaderboardMessage(@NotNull CompetitionEntry entry) {
-        Fish fish = entry.getFish();
-
         EMFMessage message = ConfigMessage.LEADERBOARD_SHORTEST_FISH.getMessage();
         message.setLength("%.1f".formatted(entry.getValue()));
-        message.setRarity(fish.getRarity().getDisplayName());
-        message.setFishCaught(fish.getDisplayName());
         return message;
     }
 


### PR DESCRIPTION
## Description
Fixes variable in the MOST_FISH leaderboard

---

### What has changed?
- The MOST_FISH leaderboard now replaces the amount variable instead of the length variable.

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.