### PR TITLE
EMFMessage empty message checks

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -41,6 +41,9 @@ public class EMFListMessage extends EMFMessage {
     }
 
     public static EMFListMessage of(@NotNull Component component) {
+        if (PLAINTEXT_SERIALIZER.serialize(component).isEmpty()) {
+            return empty();
+        }
         return new EMFListMessage(List.of(component));
     }
 
@@ -49,6 +52,9 @@ public class EMFListMessage extends EMFMessage {
     }
 
     public static EMFListMessage fromString(@NotNull String string) {
+        if (string.isEmpty()) {
+            return empty();
+        }
         return of(formatString(string));
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -105,31 +105,49 @@ public class EMFListMessage extends EMFMessage {
 
     @Override
     public void appendString(@NotNull String string) {
+        if (isEmpty()) {
+            return;
+        }
         this.message.add(formatString(string));
     }
 
     @Override
     public void appendMessage(@NotNull EMFMessage message) {
+        if (isEmpty()) {
+            return;
+        }
         this.message.addAll(message.getComponentListMessage());
     }
 
     @Override
     public void appendComponent(@NotNull Component component) {
+        if (isEmpty()) {
+            return;
+        }
         this.message.add(component);
     }
 
     @Override
     public void prependString(@NotNull String string) {
+        if (isEmpty()) {
+            return;
+        }
         this.message.add(0, formatString(string));
     }
 
     @Override
     public void prependMessage(@NotNull EMFMessage message) {
+        if (isEmpty()) {
+            return;
+        }
         this.message.addAll(0, message.getComponentListMessage());
     }
 
     @Override
     public void prependComponent(@NotNull Component component) {
+        if (isEmpty()) {
+            return;
+        }
         this.message.add(0, component);
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
@@ -135,33 +135,51 @@ public class EMFSingleMessage extends EMFMessage {
 
     @Override
     public void appendString(@NotNull String string) {
+        if (isEmpty()) {
+            return;
+        }
         this.message = this.message.append(formatString(string));
     }
 
     @Override
     public void appendMessage(@NotNull EMFMessage message) {
+        if (isEmpty()) {
+            return;
+        }
         this.message = this.message.append(message.getComponentMessage());
     }
 
     @Override
     public void appendComponent(@NotNull Component component) {
+        if (isEmpty()) {
+            return;
+        }
         this.message = this.message.append(component);
     }
 
     @Override
     public void prependString(@NotNull String string) {
+        if (isEmpty()) {
+            return;
+        }
         // Ensure the base component is always empty
         this.message = EMPTY.append(formatString(string)).append(this.message);
     }
 
     @Override
     public void prependMessage(@NotNull EMFMessage message) {
+        if (isEmpty()) {
+            return;
+        }
         // An EMFMessage base component is always empty
         this.message = message.getComponentMessage().append(this.message);
     }
 
     @Override
     public void prependComponent(@NotNull Component component) {
+        if (isEmpty()) {
+            return;
+        }
         // Ensure the base component is always empty
         this.message = EMPTY.append(component).append(this.message);
     }


### PR DESCRIPTION
## Description
Adds `isEmpty` checks for each EMFMessage append/prepend method

---

### What has changed?
- EMFMessage's append/prepend methods now check if the message is empty first.
- EMFListMessage's factories now check if single messages are empty.

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.