### PR TITLE
Bait lore fixes

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
@@ -9,6 +9,7 @@ import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.fishing.items.FishManager;
 import com.oheers.fish.fishing.items.Rarity;
 import com.oheers.fish.messages.ConfigMessage;
+import com.oheers.fish.messages.EMFListMessage;
 import com.oheers.fish.messages.EMFSingleMessage;
 import com.oheers.fish.messages.abstracted.EMFMessage;
 import com.oheers.fish.utils.ItemFactory;
@@ -120,7 +121,7 @@ public class Bait extends ConfigBase {
      */
     private List<Component> createBoostLore() {
 
-        EMFMessage lore = ConfigMessage.BAIT_BAIT_LORE.getMessage();
+        EMFListMessage lore = ConfigMessage.BAIT_BAIT_LORE.getMessage().toListMessage();
 
         Supplier<EMFMessage> boostsVariable = () -> {
             EMFMessage message = EMFSingleMessage.empty();
@@ -143,7 +144,7 @@ public class Bait extends ConfigBase {
         };
         lore.setVariable("{boosts}", boostsVariable.get());
 
-        Supplier<EMFSingleMessage> loreVariable = () -> EMFSingleMessage.fromStringList(getConfig().getStringList("lore"));
+        Supplier<EMFListMessage> loreVariable = () -> EMFListMessage.fromStringList(getConfig().getStringList("lore"));
         lore.setVariable("{lore}", loreVariable.get());
 
         lore.setBaitTheme(getTheme());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -25,7 +25,12 @@ public class EMFListMessage extends EMFMessage {
     private EMFListMessage(@Nullable List<Component> message) {
         super();
         if (message != null) {
-            this.message.addAll(message);
+            message.forEach(line -> {
+                if (line == null) {
+                    return;
+                }
+                this.message.add(EMPTY.append(line));
+            });
         }
     }
 


### PR DESCRIPTION
## Description
Fixes a couple issues with bait lore

---

### What has changed?
- Bait lore is now handled with an EMFListMessage
- EMFListMessage's constructor now prepends each line with the EMPTY component

---

### Related Issues
- Resolves bait lore not being formatted correctly
- Resolves each line of an EMFListMessage defaulting to purple when used in lore

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.