### PR TITLE
Fix missing variable in competition join message

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
@@ -70,7 +70,9 @@ public class JoinChecker implements Listener {
         if (activeComp != null) {
             activeComp.getStatusBar().addPlayer(event.getPlayer());
             if (activeComp.getStartMessage() != null) {
-                EvenMoreFish.getScheduler().runTaskLater(() -> ConfigMessage.COMPETITION_JOIN.getMessage().send(event.getPlayer()), 20L * 3);
+                EMFMessage competitionJoin = ConfigMessage.COMPETITION_JOIN.getMessage();
+                competitionJoin.setCompetitionType(activeComp.getCompetitionType().getTypeVariable().getMessage());
+                EvenMoreFish.getScheduler().runTaskLater(() -> competitionJoin.send(event.getPlayer()), 20L * 3);
             }
         }
 


### PR DESCRIPTION
## Description
Fixes a missing variable in competition join message

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.