### PR TITLE
Fix two issues

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionType.java
@@ -46,7 +46,7 @@ public enum CompetitionType {
     SHORTEST_FISH(
             ConfigMessage.COMPETITION_TYPE_SHORTEST,
             "Shortest Fish",
-            false,
+            true,
             new ShortestFishStrategy()
     ),
     SHORTEST_TOTAL(

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityFileUpdates.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityFileUpdates.java
@@ -1,15 +1,35 @@
 package com.oheers.fish.fishing.items.config;
 
 import com.oheers.fish.fishing.items.Rarity;
+import com.oheers.fish.messages.EMFSingleMessage;
+import com.oheers.fish.messages.abstracted.EMFMessage;
 import dev.dejvokep.boostedyaml.YamlDocument;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import org.jetbrains.annotations.NotNull;
 
 public class RarityFileUpdates {
 
     public static void update(@NotNull Rarity rarity) {
         YamlDocument config = rarity.getConfig();
+
+        // colour -> format
         if (config.contains("colour")) {
-            config.set("format", config.getString("colour") + "{name}");
+            String colour = config.getString("colour");
+
+            // This code is awful but handles all possible cases. Possibly look into cleaning it up later.
+            String format;
+            if (colour.contains(">") && colour.contains("</")) {
+                int closingTag = colour.indexOf(">");
+                format = colour.substring(0, closingTag + 1) + "{name}" + colour.substring(closingTag + 1);
+            } else if (colour.contains(">")) {
+                format = colour.substring(0, colour.indexOf(">") + 1) + "{name}";
+            } else {
+                format = colour + "{name}";
+            }
+
+            config.set("format", format);
+            // Remove the old colour
             config.remove("colour");
         }
 


### PR DESCRIPTION
## Description
Fixes two issues that were reported on Discord

---

### What has changed?
- Adds a (disgusting) fix for rarity formats having no colour
- Fixes SHORTEST_FISH competition type not having a reversed leaderboard

---

### Related Issues
Both reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.