### PR TITLE
Exclude command rewards from MiniMessage converter

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -620,4 +620,25 @@ public class FishUtils {
         return component;
     }
 
+    /**
+     * @param colour The original colour
+     * @return A MiniMessage string turned into a format key for use in configs.
+     */
+    public static @NotNull String getFormat(@NotNull String colour) {
+        int openingTagEnd = colour.indexOf(">");
+
+        if (openingTagEnd == -1) {
+            return colour + "{name}";  // No tags at all
+        }
+
+        // At least one opening tag exists
+        if (colour.contains("</")) {
+            // Case: <tag>content</tag> → <tag>{name}content</tag>
+            return colour.substring(0, openingTagEnd + 1) + "{name}" + colour.substring(openingTagEnd + 1);
+        }
+
+        // Case: <tag> → <tag>{name}
+        return colour.substring(0, openingTagEnd + 1) + "{name}";
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
@@ -206,16 +206,21 @@ public class ConfigBase {
      * If the message already contains a MiniMessage tag, this does nothing.
      */
     private String convertLegacyString(@NotNull String message) {
-        // Get MiniMessage serializer
-        final MiniMessage miniMessageSerializer = MiniMessage.builder()
-            .strict(true)
-            .postProcessor(component -> component)
-            .build();
+        // Exclude command reward types
+        if (message.toUpperCase().startsWith("COMMAND:")) {
+            return message;
+        }
 
         // If the message isn't legacy, don't do anything
         if (!FishUtils.isLegacyString(message)) {
             return message;
         }
+
+        // Get MiniMessage serializer
+        final MiniMessage miniMessageSerializer = MiniMessage.builder()
+            .strict(true)
+            .postProcessor(component -> component)
+            .build();
 
         // Get LegacyComponentSerializer
         final LegacyComponentSerializer legacySerializer = LegacyComponentSerializer.builder()

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityFileUpdates.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityFileUpdates.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.fishing.items.config;
 
+import com.oheers.fish.FishUtils;
 import com.oheers.fish.fishing.items.Rarity;
 import com.oheers.fish.messages.EMFSingleMessage;
 import com.oheers.fish.messages.abstracted.EMFMessage;
@@ -16,17 +17,7 @@ public class RarityFileUpdates {
         // colour -> format
         if (config.contains("colour")) {
             String colour = config.getString("colour");
-
-            // This code is awful but handles all possible cases. Possibly look into cleaning it up later.
-            String format;
-            if (colour.contains(">") && colour.contains("</")) {
-                int closingTag = colour.indexOf(">");
-                format = colour.substring(0, closingTag + 1) + "{name}" + colour.substring(closingTag + 1);
-            } else if (colour.contains(">")) {
-                format = colour.substring(0, colour.indexOf(">") + 1) + "{name}";
-            } else {
-                format = colour + "{name}";
-            }
+            String format = FishUtils.getFormat(colour);
 
             config.set("format", format);
             // Remove the old colour


### PR DESCRIPTION
## Description
Title

---

### What has changed?
- The ConfigBase#convertLegacyString method now ignores lines that start with `COMMAND:`

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.