### PR TITLE
1.21.5 Support

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -270,10 +270,9 @@ tasks {
             attributes["Database-Baseline-Version"] = "7.0"
         }
 
-        minimize {
-            exclude(dependency("net.kyori:.*"))
-        }
+        minimize()
 
+        exclude("LICENSE")
         exclude("META-INF/**")
 
         archiveFileName.set("even-more-fish-${project.version}-${buildNumberOrDate}.jar")

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -133,7 +133,6 @@ public class EvenMoreFish extends EMFPlugin {
     public void onLoad() {
         CommandAPIBukkitConfig config = new CommandAPIBukkitConfig(this)
                 .shouldHookPaperReload(true)
-                .usePluginNamespace()
                 .missingExecutorImplementationMessage("You are not able to use this command!");
         CommandAPI.onLoad(config);
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
@@ -8,16 +8,11 @@ import com.oheers.fish.competition.CompetitionStrategy;
 import com.oheers.fish.competition.CompetitionType;
 import com.oheers.fish.competition.leaderboard.Leaderboard;
 import com.oheers.fish.fishing.items.Fish;
-import com.oheers.fish.fishing.items.FishManager;
 import com.oheers.fish.fishing.items.Rarity;
 import com.oheers.fish.messages.ConfigMessage;
 import com.oheers.fish.messages.abstracted.EMFMessage;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
 
 public class SpecificRarityStrategy implements CompetitionStrategy {
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityFileUpdates.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityFileUpdates.java
@@ -2,11 +2,7 @@ package com.oheers.fish.fishing.items.config;
 
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.fishing.items.Rarity;
-import com.oheers.fish.messages.EMFSingleMessage;
-import com.oheers.fish.messages.abstracted.EMFMessage;
 import dev.dejvokep.boostedyaml.YamlDocument;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import org.jetbrains.annotations.NotNull;
 
 public class RarityFileUpdates {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -73,7 +73,7 @@ dependencyResolutionManagement {
             library("commandapi", "dev.jorel:commandapi-bukkit-shade:10.0.0")
             library("inventorygui", "de.themoep:inventorygui:1.6.4-SNAPSHOT")
 
-            plugin("shadow", "com.gradleup.shadow").version("8.3.5")
+            plugin("shadow", "com.gradleup.shadow").version("9.0.0-beta12")
             plugin("plugin-yml", "de.eldoria.plugin-yml.bukkit").version("0.7.1")
 
             library("boostedyaml", "dev.dejvokep:boosted-yaml:1.3.7")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,7 @@ include(":even-more-fish-plugin")
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            library("paper-api", "io.papermc.paper:paper-api:1.20-R0.1-SNAPSHOT")
+            library("paper-api", "io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
             library("vault-api", "com.github.MilkBowl:VaultAPI:1.7.1")
             library("placeholder-api", "me.clip:placeholderapi:2.11.6")
             library("bstats", "org.bstats:bstats-bukkit:3.1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
             library("worldguard-bukkit", "com.sk89q.worldguard","worldguard-bukkit").versionRef("worldguard")
             bundle("worldguard", listOf("worldguard-core", "worldguard-bukkit"))
 
-            version("worldedit", "7.2.17") //We must use 7.2.17 until we compile against a newer Minecraft version
+            version("worldedit", "7.3.0") // 7.3.0 is the last version that supports 1.20.1 and Java 17
             library("worldedit-core", "com.sk89q.worldedit","worldedit-core").versionRef("worldedit")
             library("worldedit-bukkit", "com.sk89q.worldedit","worldedit-bukkit").versionRef("worldedit")
             bundle("worldedit", listOf("worldedit-core", "worldedit-bukkit"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -91,7 +91,7 @@ dependencyResolutionManagement {
             library("connectors-sqlite", "org.xerial:sqlite-jdbc:3.47.1.0")
             library("connectors-h2", "com.h2database:h2:2.3.232")
 
-            library("maven-artifact", "org.apache.maven:maven-artifact:4.0.0-rc-2")
+            library("maven-artifact", "org.apache.maven:maven-artifact:4.0.0-rc-3")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -70,7 +70,7 @@ dependencyResolutionManagement {
 
             library("vanishchecker", "uk.firedev:VanishChecker:1.0.5")
 
-            library("commandapi", "dev.jorel:commandapi-bukkit-shade:9.7.0")
+            library("commandapi", "dev.jorel:commandapi-bukkit-shade:10.0.0")
             library("inventorygui", "de.themoep:inventorygui:1.6.4-SNAPSHOT")
 
             plugin("shadow", "com.gradleup.shadow").version("8.3.5")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ dependencyResolutionManagement {
             library("placeholder-api", "me.clip:placeholderapi:2.11.6")
             library("bstats", "org.bstats:bstats-bukkit:3.1.0")
 
-            version("worldguard", "7.0.5") //We must use 7.0.5 until we compile against a newer Minecraft version
+            version("worldguard", "7.0.9") // 7.0.9 is the last version that supports 1.20.1
             library("worldguard-core", "com.sk89q.worldguard","worldguard-core").versionRef("worldguard")
             library("worldguard-bukkit", "com.sk89q.worldguard","worldguard-bukkit").versionRef("worldguard")
             bundle("worldguard", listOf("worldguard-core", "worldguard-bukkit"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,7 @@ dependencyResolutionManagement {
             library("griefprevention", "com.github.TechFortress:GriefPrevention:16.17.1")
 
             library("itemsadder-api", "com.github.LoneDev6:API-ItemsAdder:3.6.1")
-            library("nbt-api", "de.tr7zw:item-nbt-api:2.14.2-SNAPSHOT")
+            library("nbt-api", "de.tr7zw:item-nbt-api:2.15.0")
             library("denizen-api", "com.denizenscript:denizen:1.3.1-SNAPSHOT")
             library("oraxen", "io.th0rgal:oraxen:1.188.0")
             library("nexo", "com.nexomc:nexo:1.0.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,7 @@ dependencyResolutionManagement {
             library("griefprevention", "com.github.TechFortress:GriefPrevention:16.17.1")
 
             library("itemsadder-api", "com.github.LoneDev6:API-ItemsAdder:3.6.1")
-            library("nbt-api", "de.tr7zw:item-nbt-api:2.14.1")
+            library("nbt-api", "de.tr7zw:item-nbt-api:2.14.2-SNAPSHOT")
             library("denizen-api", "com.denizenscript:denizen:1.3.1-SNAPSHOT")
             library("oraxen", "io.th0rgal:oraxen:1.188.0")
             library("nexo", "com.nexomc:nexo:1.0.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -78,7 +78,7 @@ dependencyResolutionManagement {
 
             library("boostedyaml", "dev.dejvokep:boosted-yaml:1.3.7")
 
-            plugin("grgit", "org.ajoberstar.grgit").version("5.2.2")
+            plugin("grgit", "org.ajoberstar.grgit").version("5.3.0")
 
             version("jooq", "3.19.18")
             library("jooq", "org.jooq","jooq").versionRef("jooq")


### PR DESCRIPTION
## Description
Allows the plugin to run on 1.21.5 and updates some dependencies.

This will be merged after NBT-API pushes a proper release for 1.21.5.

Closes #596 

---

### What has changed?
- Updated CommandAPI to 10.0.0
- Updated NBT-API to 2.15.0
- Resolved a CommandAPI deprecation
- Updated Shadow to 9.0.0-beta12
- Updated Paper API to 1.20.1 as nobody is using 1.20.0
- Updated WorldGuard to 7.0.9
- Updated WorldEdit to 7.3.0
- Updated grgit to 5.3.0
- Updated maven-artifact to 4.0.0-rc-3

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.