### PR TITLE
Fixes issue with addons build

### DIFF
--- a/buildSrc/src/main/kotlin/com.oheers.evenmorefish.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.oheers.evenmorefish.java-conventions.gradle.kts
@@ -16,18 +16,6 @@ tasks {
         jar {
             archiveFileName.set(addonName)
         }
-        build {
-            doLast {
-                copy {
-
-                    val sourceFolder = project.layout.buildDirectory.dir("libs/${addonName}").get()
-                    val targetFolder = File(rootProject.project(":even-more-fish-plugin").projectDir, "src/main/resources/addons")
-                    from(sourceFolder)
-                    into(targetFolder)
-                    logger.lifecycle("Copying $addonName from $sourceFolder to $targetFolder")
-                }
-            }
-        }
     }
 }
 

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -229,6 +229,20 @@ tasks.named("compileJava") {
     dependsOn(":even-more-fish-plugin:generateMysqlJooq")
 }
 
+val copyAddons by tasks.registering(Copy::class) {
+    // Make sure the plugin waits for the addons to be built first
+    dependsOn(":addons:even-more-fish-addons-j17:build", ":addons:even-more-fish-addons-j21:build")
+
+    from(project(":addons:even-more-fish-addons-j17").layout.buildDirectory.dir("libs"))
+    from(project(":addons:even-more-fish-addons-j21").layout.buildDirectory.dir("libs"))
+
+    into(file("src/main/resources/addons"))
+}
+
+tasks.named("processResources") {
+    dependsOn(copyAddons)
+}
+
 tasks {
     build {
         dependsOn(


### PR DESCRIPTION
## Description
Process resources now depends on addons build.

---

### What has changed?
Moved addons move logic to plugin.

---

### Related Issues
Issue with addons not being copied over.

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.