### PR TITLE
Add MiniMessage converter exclusions

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionFile.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionFile.java
@@ -321,4 +321,11 @@ public class CompetitionFile extends ConfigBase {
         return getConfig().getBoolean("allow-fishing", true);
     }
 
+    @Override
+    public List<String> getMiniMessageExclusions() {
+        return List.of(
+            "start-commands"
+        );
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
@@ -180,12 +180,20 @@ public class ConfigBase {
 
     // MiniMessage conversion methods. DO NOT REMOVE
 
+    public List<String> getMiniMessageExclusions() {
+        return List.of();
+    }
+
     /**
      * Converts all Legacy colors to MiniMessage.
      */
     @SuppressWarnings("unchecked")
     public void convertLegacy(@NotNull YamlDocument document) {
+        List<String> excludedKeys = getMiniMessageExclusions();
         for (String key : document.getRoutesAsStrings(true)) {
+            if (excludedKeys.contains(key)) {
+                continue;
+            }
             if (document.isString(key)) {
                 String updated = convertLegacyString(document.getString(key));
                 document.set(key, updated);


### PR DESCRIPTION
## Description
Title

---

### What has changed?
`start-commands` in competition files is no longer converted to MiniMessage

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.