### PR TITLE
Fix Specific Fish and Specific Rarity competitions

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
@@ -21,13 +21,27 @@ public class SpecificFishStrategy implements CompetitionStrategy {
 
     @Override
     public boolean begin(Competition competition) {
+        // Check if the competition fish is valid
+        if (!competition.chooseFish()) {
+            EvenMoreFish.getInstance().getLogger().warning(
+                "Failed to select a fish for " + competition.getCompetitionFile().getId() + " competition."
+            );
+            return false;
+        }
+        // Set number-needed to 1 if it's not configured
         if (competition.getNumberNeeded() == 0) {
             EvenMoreFish.getInstance().getLogger().warning(
                 competition.getCompetitionFile().getId() + " competition does not have number-needed set. Defaulting to 1."
             );
             competition.setNumberNeeded(1);
         }
-        return competition.getSelectedFish() != null;
+        if (competition.getSelectedFish() == null) {
+            EvenMoreFish.getInstance().getLogger().warning(
+                "Failed to select a fish for " + competition.getCompetitionFile().getId() + " competition."
+            );
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
@@ -23,13 +23,27 @@ public class SpecificRarityStrategy implements CompetitionStrategy {
 
     @Override
     public boolean begin(Competition competition) {
+        // Check if the competition rarity is valid
+        if (!competition.chooseRarity()) {
+            EvenMoreFish.getInstance().getLogger().warning(
+                "Failed to select a rarity for " + competition.getCompetitionFile().getId() + " competition."
+            );
+            return false;
+        }
+        // Set number-needed to 1 if it's not configured
         if (competition.getNumberNeeded() == 0) {
             EvenMoreFish.getInstance().getLogger().warning(
                 competition.getCompetitionFile().getId() + " competition does not have number-needed set. Defaulting to 1."
             );
             competition.setNumberNeeded(1);
         }
-        return competition.getSelectedRarity() != null;
+        if (competition.getSelectedRarity() == null) {
+            EvenMoreFish.getInstance().getLogger().warning(
+                "Failed to select a rarity for " + competition.getCompetitionFile().getId() + " competition."
+            );
+            return false;
+        }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## Description
Fixes an issue with Specific Fish and Specific rarity comps

---

### What has changed?
- SpecificFishStrategy now initializes the fish in its begin method
- SpecificRarityStrategy now initializes the rarity in its begin method

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.