### PR TITLE
Fixes #643

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -98,7 +98,7 @@ public class ItemFactory {
      */
     public ItemStack createItem(OfflinePlayer player, int randomIndex, @Nullable Map<String, EMFMessage> replacements) {
         if (rawMaterial) {
-            return this.product;
+            return this.product.clone();
         }
         if (itemRandom && player != null) {
             applyItemRandomType(player, randomIndex);
@@ -128,7 +128,7 @@ public class ItemFactory {
 
         applyFlags();
 
-        return product;
+        return product.clone();
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes incorrect item quantities in fish

---

### What has changed?
- ItemFactory#createItem now returns a clone of the item.

---

### Related Issues
Closes #643 

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.