### PR TITLE
Fix a few bugs

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -335,12 +335,9 @@ public class FishUtils {
     }
 
     public static void broadcastFishMessage(EMFMessage message, Player referencePlayer, boolean actionBar) {
-        String plain = message.getPlainTextMessage();
         Competition activeComp = Competition.getCurrentlyActive();
 
-        if (plain.isEmpty() || activeComp == null) {
-            EvenMoreFish.getInstance().debug("Formatted (Empty Message) " + plain.isEmpty());
-            EvenMoreFish.getInstance().debug("Active Comp is null? " + (activeComp == null));
+        if (message.isEmpty()) {
             return;
         }
 
@@ -355,7 +352,11 @@ public class FishUtils {
         }
     }
 
-    private static @NotNull List<? extends Player> getValidPlayers(@NotNull Player referencePlayer, @NotNull Competition activeComp) {
+    private static @NotNull List<? extends Player> getValidPlayers(@NotNull Player referencePlayer, @Nullable Competition activeComp) {
+        if (activeComp == null) {
+            return Bukkit.getOnlinePlayers().stream().toList();
+        }
+
         CompetitionFile activeCompetitionFile = activeComp.getCompetitionFile();
 
         // Get the list of online players once and store in a variable.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/configs/BaitConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/configs/BaitConversions.java
@@ -4,6 +4,7 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.config.ConfigBase;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.MessageConfig;
+import com.oheers.fish.utils.Logging;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.jetbrains.annotations.NotNull;
@@ -47,7 +48,7 @@ public class BaitConversions {
         file.renameTo(new File(EvenMoreFish.getInstance().getDataFolder(), "baits.yml.old"));
         file.delete();
 
-        EvenMoreFish.getInstance().getLogger().severe("Your bait configs have been automatically converted to the new format.");
+        Logging.infoComponent("<yellow>Your bait configs have been automatically converted to the new format.");
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -59,6 +59,7 @@ public class Competition {
     private MyScheduledTask timingSystem;
     private CompetitionFile competitionFile;
     private int numberNeeded = 0;
+    private Player singleWinner = null;
 
     public Competition(final @NotNull CompetitionFile competitionFile) {
         this.competitionFile = competitionFile;
@@ -152,7 +153,11 @@ public class Competition {
                     ConfigMessage.COMPETITION_END.getMessage().send(player);
                     sendLeaderboard(player);
                 }
-                handleRewards();
+                if (competitionType.getStrategy().isSingleReward() && singleWinner != null) {
+                    singleReward(singleWinner);
+                } else {
+                    handleRewards();
+                }
                 if (originallyRandom) {
                     competitionType = CompetitionType.RANDOM;
                 }
@@ -353,6 +358,7 @@ public class Competition {
     }
 
     private void handleRewards() {
+
         if (leaderboard.getSize() == 0) {
             if (!((competitionType == CompetitionType.SPECIFIC_FISH || competitionType == CompetitionType.SPECIFIC_RARITY) && numberNeeded == 1)) {
                 ConfigMessage.NO_WINNERS.getMessage().broadcast();
@@ -396,7 +402,7 @@ public class Competition {
         }
     }
 
-    public void singleReward(Player player) {
+    private void singleReward(Player player) {
         EMFMessage message = getTypeFormat(ConfigMessage.COMPETITION_SINGLE_WINNER);
         message.setPlayer(player);
         message.setCompetitionType(competitionType.getTypeVariable().getMessage());
@@ -570,6 +576,10 @@ public class Competition {
             EvenMoreFish.getInstance().getLogger().log(Level.SEVERE, exception.getMessage(), exception);
             return false;
         }
+    }
+
+    public void setSingleWinner(@Nullable Player player) {
+        this.singleWinner = player;
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionStrategy.java
@@ -91,4 +91,6 @@ public interface CompetitionStrategy {
 
     boolean shouldUseFishLength();
 
+    boolean isSingleReward();
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
@@ -56,8 +56,8 @@ public class JoinChecker implements Listener {
                 DataManager.getInstance().cacheUser(userUUID, userReport, fishReports);
             } else {
                 EvenMoreFish.getInstance().getLogger().severe("Null value when fetching data for user (" + userName + "),\n" +
-                        "UserReport: " + (userReport == null) +
-                        ",\nFishReports: " + (fishReports != null && !fishReports.isEmpty()));
+                    "UserReport: " + (userReport == null) +
+                    ",\nFishReports: " + (fishReports != null && !fishReports.isEmpty()));
             }
         });
 
@@ -69,11 +69,15 @@ public class JoinChecker implements Listener {
         Competition activeComp = Competition.getCurrentlyActive();
         if (activeComp != null) {
             activeComp.getStatusBar().addPlayer(event.getPlayer());
-            if (activeComp.getStartMessage() != null) {
-                EMFMessage competitionJoin = ConfigMessage.COMPETITION_JOIN.getMessage();
-                competitionJoin.setCompetitionType(activeComp.getCompetitionType().getTypeVariable().getMessage());
-                EvenMoreFish.getScheduler().runTaskLater(() -> competitionJoin.send(event.getPlayer()), 20L * 3);
+            if (activeComp.getStartMessage() == null) {
+                return;
             }
+
+            EMFMessage message = activeComp.getCompetitionType().getStrategy().getTypeFormat(
+                activeComp, ConfigMessage.COMPETITION_JOIN
+            );
+
+            EvenMoreFish.getScheduler().runTaskLater(() -> message.send(event.getPlayer()), 20L * 3);
         }
 
         EvenMoreFish.getScheduler().runTaskAsynchronously(() -> databaseRegistration(event.getPlayer().getUniqueId(), event.getPlayer().getName()));
@@ -112,6 +116,6 @@ public class JoinChecker implements Listener {
 
             DataManager.getInstance().uncacheUser(userUUID);
         });
-        
+
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
@@ -2,6 +2,7 @@ package com.oheers.fish.competition.configs;
 
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.config.ConfigBase;
+import com.oheers.fish.utils.Logging;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.jetbrains.annotations.NotNull;
@@ -48,7 +49,7 @@ public class CompetitionConversions {
         file.renameTo(new File(EvenMoreFish.getInstance().getDataFolder(), "competitions.yml.old"));
         file.delete();
 
-        EvenMoreFish.getInstance().getLogger().severe("Your competition configs have been automatically converted to the new format.");
+        Logging.infoComponent("<yellow>Your competition configs have been automatically converted to the new format.");
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/LargestFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/LargestFishStrategy.java
@@ -52,4 +52,9 @@ public class LargestFishStrategy implements CompetitionStrategy {
     public boolean shouldUseFishLength() {
         return true;
     }
+
+    @Override
+    public boolean isSingleReward() {
+        return false;
+    }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/LargestTotalStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/LargestTotalStrategy.java
@@ -51,4 +51,9 @@ public class LargestTotalStrategy implements CompetitionStrategy {
         return true;
     }
 
+    @Override
+    public boolean isSingleReward() {
+        return false;
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/MostFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/MostFishStrategy.java
@@ -69,4 +69,9 @@ public class MostFishStrategy implements CompetitionStrategy {
         return new DecimalFormat();
     }
 
+    @Override
+    public boolean isSingleReward() {
+        return false;
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/NullStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/NullStrategy.java
@@ -50,4 +50,9 @@ public class NullStrategy implements CompetitionStrategy {
         return true;
     }
 
+    @Override
+    public boolean isSingleReward() {
+        return false;
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/RandomStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/RandomStrategy.java
@@ -99,4 +99,9 @@ public class RandomStrategy implements CompetitionStrategy {
         return randomType.getStrategy().getDecimalFormat();
     }
 
+    @Override
+    public boolean isSingleReward() {
+        return randomType.getStrategy().isSingleReward();
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/ShortestFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/ShortestFishStrategy.java
@@ -53,4 +53,9 @@ public class ShortestFishStrategy implements CompetitionStrategy {
         return true;
     }
 
+    @Override
+    public boolean isSingleReward() {
+        return false;
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/ShortestTotalStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/ShortestTotalStrategy.java
@@ -52,4 +52,9 @@ public class ShortestTotalStrategy implements CompetitionStrategy {
         return true;
     }
 
+    @Override
+    public boolean isSingleReward() {
+        return false;
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
@@ -58,10 +58,11 @@ public class SpecificFishStrategy implements CompetitionStrategy {
             entry.incrementValue(increaseAmount);
             leaderboard.updateEntry(entry);
         } else {
-            leaderboard.addEntry(new CompetitionEntry(fisher.getUniqueId(), fish, competition.getCompetitionType()));
+            entry = new CompetitionEntry(fisher.getUniqueId(), fish, competition.getCompetitionType());
+            leaderboard.addEntry(entry);
         }
 
-        if (entry != null && entry.getValue() >= competition.getNumberNeeded()) {
+        if (entry.getValue() >= competition.getNumberNeeded()) {
             competition.singleReward(fisher);
             competition.end(false);
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
@@ -63,7 +63,7 @@ public class SpecificFishStrategy implements CompetitionStrategy {
         }
 
         if (entry.getValue() >= competition.getNumberNeeded()) {
-            competition.singleReward(fisher);
+            competition.setSingleWinner(fisher);
             competition.end(false);
         }
     }
@@ -117,6 +117,11 @@ public class SpecificFishStrategy implements CompetitionStrategy {
 
     @Override
     public boolean shouldUseFishLength() {
+        return true;
+    }
+
+    @Override
+    public boolean isSingleReward() {
         return true;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
@@ -60,10 +60,11 @@ public class SpecificRarityStrategy implements CompetitionStrategy {
             entry.incrementValue(increaseAmount);
             leaderboard.updateEntry(entry);
         } else {
-            leaderboard.addEntry(new CompetitionEntry(fisher.getUniqueId(), fish, competition.getCompetitionType()));
+            entry = new CompetitionEntry(fisher.getUniqueId(), fish, competition.getCompetitionType());
+            leaderboard.addEntry(entry);
         }
 
-        if (entry != null && entry.getValue() >= competition.getNumberNeeded()) {
+        if (entry.getValue() >= competition.getNumberNeeded()) {
             competition.singleReward(fisher);
             competition.end(false);
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
@@ -65,7 +65,7 @@ public class SpecificRarityStrategy implements CompetitionStrategy {
         }
 
         if (entry.getValue() >= competition.getNumberNeeded()) {
-            competition.singleReward(fisher);
+            competition.setSingleWinner(fisher);
             competition.end(false);
         }
     }
@@ -117,6 +117,11 @@ public class SpecificRarityStrategy implements CompetitionStrategy {
 
     @Override
     public boolean shouldUseFishLength() {
+        return true;
+    }
+
+    @Override
+    public boolean isSingleReward() {
         return true;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/Processor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/Processor.java
@@ -148,7 +148,7 @@ public abstract class Processor<E extends Event> implements Listener {
             message.setFishCaught(fish.getDisplayName());
             message.setRarity(fish.getRarity().getDisplayName());
 
-            if (fish.getRarity().getAnnounce() && Competition.isActive()) {
+            if (fish.getRarity().getAnnounce()) {
                 FishUtils.broadcastFishMessage(message, player, false);
             } else {
                 message.send(player);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/FishConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/FishConversions.java
@@ -2,6 +2,7 @@ package com.oheers.fish.fishing.items.config;
 
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.config.ConfigBase;
+import com.oheers.fish.utils.Logging;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,8 +43,8 @@ public class FishConversions extends RarityConversions {
         file.renameTo(new File(EvenMoreFish.getInstance().getDataFolder(), "fish.yml.old"));
         file.delete();
 
-        EvenMoreFish.getInstance().getLogger().severe("Your fish configs have been automatically converted to the new format.");
-        EvenMoreFish.getInstance().getLogger().severe("They are now located in the rarity files.");
+        Logging.infoComponent("<yellow>Your fish configs have been automatically converted to the new format.");
+        Logging.infoComponent("<yellow>They are now located in the rarity files.");
     }
 
     private void convertSectionToFile(@NotNull Section section) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityConversions.java
@@ -2,6 +2,7 @@ package com.oheers.fish.fishing.items.config;
 
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.config.ConfigBase;
+import com.oheers.fish.utils.Logging;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.jetbrains.annotations.NotNull;
@@ -41,7 +42,7 @@ public class RarityConversions {
         file.renameTo(new File(EvenMoreFish.getInstance().getDataFolder(), "rarities.yml.old"));
         file.delete();
 
-        EvenMoreFish.getInstance().getLogger().severe("Your rarity configs have been automatically converted to the new format.");
+        Logging.infoComponent("<yellow>Your rarity configs have been automatically converted to the new format.");
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/Logging.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/Logging.java
@@ -1,0 +1,38 @@
+package com.oheers.fish.utils;
+
+import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.messages.EMFSingleMessage;
+
+public class Logging {
+
+    public static void info(String message) {
+        EvenMoreFish.getInstance().getLogger().info(message);
+    }
+
+    public static void infoComponent(String message) {
+        EvenMoreFish.getInstance().getComponentLogger().info(
+            EMFSingleMessage.fromString(message).getComponentMessage()
+        );
+    }
+
+    public static void warn(String message) {
+        EvenMoreFish.getInstance().getLogger().warning(message);
+    }
+
+    public static void warnComponent(String message) {
+        EvenMoreFish.getInstance().getComponentLogger().warn(
+            EMFSingleMessage.fromString(message).getComponentMessage()
+        );
+    }
+
+    public static void error(String message) {
+        EvenMoreFish.getInstance().getLogger().severe(message);
+    }
+
+    public static void errorComponent(String message) {
+        EvenMoreFish.getInstance().getComponentLogger().error(
+            EMFSingleMessage.fromString(message).getComponentMessage()
+        );
+    }
+
+}


### PR DESCRIPTION
## Description
Fixes various bugs reported on Discord

---

### What has changed?
- The SPECIFIC competition types no longer require an extra catch.
- The SPECIFIC competition types no longer give rewards twice.
- Fixed variables in the competition join message.
- Fixed broadcasts not working outside of competitions.
- All automatic config conversions now use ComponentLogger for color instead of errors.

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.