### PR TITLE
2.0.0-RC4

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -603,7 +603,7 @@ public class AdminCommand {
                         ConfigMessage.COMPETITION_ALREADY_RUNNING.getMessage().send(sender);
                         return;
                     }
-                    final int duration = (int) args.getOptional("duration").orElse(1);
+                    final int duration = (int) args.getOptional("duration").orElse(60);
                     final CompetitionType type = (CompetitionType) args.getOptional("competitionType").orElse(CompetitionType.LARGEST_FISH);
                     CompetitionFile file = new CompetitionFile("adminTest", type, duration);
                     Competition competition = new Competition(file);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -84,8 +84,12 @@ public class Competition {
         this.competitionType = type;
     }
 
+    /**
+     * Sets the maximum duration of the competition in seconds.
+     * @param duration The maximum duration of the competition in seconds.
+     */
     public void setMaxDuration(int duration) {
-        this.maxDuration = duration * 60L;
+        this.maxDuration = duration;
     }
 
     public static boolean isActive() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
@@ -786,13 +786,15 @@ public class Database implements DatabaseAPI {
 
 
     public void updateCompetition(CompetitionReport competition) {
+        String winnerUuid = competition.getWinnerUuid() == null ? "None" : competition.getWinnerUuid().toString();
+
         new ExecuteUpdate(connectionFactory, settings) {
             @Override
             protected int onRunUpdate(DSLContext dslContext) {
                 return dslContext.insertInto(Tables.COMPETITIONS)
                         .set(Tables.COMPETITIONS.COMPETITION_NAME, competition.getCompetitionConfigId())
                         .set(Tables.COMPETITIONS.WINNER_FISH, competition.getWinnerFish())
-                        .set(Tables.COMPETITIONS.WINNER_UUID, competition.getWinnerUuid().toString())
+                        .set(Tables.COMPETITIONS.WINNER_UUID, winnerUuid)
                         .set(Tables.COMPETITIONS.WINNER_SCORE, competition.getWinnerScore())
                         .set(Tables.COMPETITIONS.CONTESTANTS, competition.getContestants().stream().map(UUID::toString).collect(Collectors.joining(", ")))
                         .set(Tables.COMPETITIONS.START_TIME, competition.getStartTime())

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
@@ -90,44 +90,52 @@ public class FishJournalGui extends ConfigGui {
             return factory.createItem(null, -1);
         }
 
-        ItemFactory factory = new ItemFactory("fish-item", section);
-        factory.enableAllChecks();
-        ItemStack item = factory.createItem(null, -1);
+        ItemStack item = fish.give(-1);
+
         item.editMeta(meta -> {
-            // Display Name
-            final String displayStr = section.getString("fish-item.item.displayname");
-            if (displayStr != null) {
-                EMFSingleMessage display = EMFSingleMessage.fromString(displayStr);
-                display.setVariable("{fishname}", fish.getDisplayName());
+            EMFSingleMessage display = prepareDisplay(section, fish);
+            if (display != null) {
                 meta.displayName(display.getComponentMessage());
             }
-
-            final int userId = EvenMoreFish.getInstance().getUserManager().getUserId(player.getUniqueId());
-
-            final UserFishStats userFishStats = EvenMoreFish.getInstance().getUserFishStatsDataManager().get(UserFishRarityKey.of(userId, fish).toString());
-            final FishStats fishStats = EvenMoreFish.getInstance().getFishStatsDataManager().get(FishRarityKey.of(fish).toString());
-
-            final String discoverDate = getValueOrUnknown(() -> userFishStats.getFirstCatchTime().format(DateTimeFormatter.ISO_DATE));
-            final String discoverer = getValueOrUnknown(() -> FishUtils.getPlayerName(fishStats.getDiscoverer()));
-
-            EMFListMessage lore = EMFListMessage.fromStringList(
-                    section.getStringList("fish-item.lore")
-            );
-
-            lore.setVariable("{times-caught}", getValueOrUnknown(() -> Integer.toString(userFishStats.getQuantity())));
-            lore.setVariable("{largest-size}", getValueOrUnknown(() -> String.valueOf(userFishStats.getLongestLength())));
-            lore.setVariable("{smallest-size}", getValueOrUnknown(() -> String.valueOf(userFishStats.getShortestLength())));
-            lore.setVariable("{discover-date}", discoverDate);
-            lore.setVariable("{discoverer}", discoverer);
-            lore.setVariable("{server-largest}", getValueOrUnknown(() -> String.valueOf(fishStats.getLongestLength())));
-            lore.setVariable("{server-smallest}", getValueOrUnknown(() -> String.valueOf(fishStats.getShortestLength())));
-            lore.setVariable("{server-caught}", getValueOrUnknown(() -> String.valueOf(fishStats.getQuantity())));
-            meta.lore(lore.getComponentListMessage());
+            meta.lore(prepareLore(section, fish).getComponentListMessage());
         });
 
-        ItemUtils.changeMaterial(item, fish.getFactory().getMaterial());
-
         return item;
+    }
+
+    private @Nullable EMFSingleMessage prepareDisplay(@NotNull Section section, @NotNull Fish fish) {
+        final String displayStr = section.getString("fish-item.item.displayname");
+        if (displayStr == null) {
+            return null;
+        }
+        EMFSingleMessage display = EMFSingleMessage.fromString(displayStr);
+        display.setVariable("{fishname}", fish.getDisplayName());
+        return display;
+    }
+
+    private @NotNull EMFListMessage prepareLore(@NotNull Section section, @NotNull Fish fish) {
+        final int userId = EvenMoreFish.getInstance().getUserManager().getUserId(player.getUniqueId());
+
+        final UserFishStats userFishStats = EvenMoreFish.getInstance().getUserFishStatsDataManager().get(UserFishRarityKey.of(userId, fish).toString());
+        final FishStats fishStats = EvenMoreFish.getInstance().getFishStatsDataManager().get(FishRarityKey.of(fish).toString());
+
+        final String discoverDate = getValueOrUnknown(() -> userFishStats.getFirstCatchTime().format(DateTimeFormatter.ISO_DATE));
+        final String discoverer = getValueOrUnknown(() -> FishUtils.getPlayerName(fishStats.getDiscoverer()));
+
+        EMFListMessage lore = EMFListMessage.fromStringList(
+            section.getStringList("fish-item.lore")
+        );
+
+        lore.setVariable("{times-caught}", getValueOrUnknown(() -> Integer.toString(userFishStats.getQuantity())));
+        lore.setVariable("{largest-size}", getValueOrUnknown(() -> String.valueOf(userFishStats.getLongestLength())));
+        lore.setVariable("{smallest-size}", getValueOrUnknown(() -> String.valueOf(userFishStats.getShortestLength())));
+        lore.setVariable("{discover-date}", discoverDate);
+        lore.setVariable("{discoverer}", discoverer);
+        lore.setVariable("{server-largest}", getValueOrUnknown(() -> String.valueOf(fishStats.getLongestLength())));
+        lore.setVariable("{server-smallest}", getValueOrUnknown(() -> String.valueOf(fishStats.getShortestLength())));
+        lore.setVariable("{server-caught}", getValueOrUnknown(() -> String.valueOf(fishStats.getQuantity())));
+
+        return lore;
     }
 
     @NotNull


### PR DESCRIPTION
## Description
Quick update to fix a missed bug and a parity issue with 1.7.3

---

### What has changed?
- Fish in the Journal menu now keep their custom textures
- The admin competition commands now use seconds for their duration (for parity with 1.7.3)
- Fixed a database error when a competition has no winner

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.