### PR TITLE
Fix Journal Items

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/items/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/items/ItemFactory.java
@@ -44,11 +44,11 @@ public class ItemFactory {
     private final LoreItemConfig lore;
     private final PotionMetaItemConfig potionMeta;
 
-    private ItemFactory(@NotNull Section configuration, @Nullable String configLocation) {
+    private ItemFactory(@NotNull Section initialSection, @Nullable String configLocation) {
         if (configLocation == null) {
-            this.configuration = configuration;
+            this.configuration = initialSection;
         } else {
-            this.configuration = ConfigUtils.getOrCreateSection(configuration, configLocation);
+            this.configuration = ConfigUtils.getOrCreateSection(initialSection, configLocation);
         }
 
         // Updates the configuration to put everything in the correct place

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/items/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/items/ItemFactory.java
@@ -54,13 +54,13 @@ public class ItemFactory {
         // Updates the configuration to put everything in the correct place
         new ItemFactoryConversion().performConversions(this.configuration);
 
-        this.customModelData = new CustomModelDataItemConfig(configuration);
-        this.itemDamage = new ItemDamageItemConfig(configuration);
-        this.displayName = new DisplayNameItemConfig(configuration);
-        this.dyeColour = new DyeColourItemConfig(configuration);
-        this.glowing = new GlowingItemConfig(configuration);
-        this.lore = new LoreItemConfig(configuration);
-        this.potionMeta = new PotionMetaItemConfig(configuration);
+        this.customModelData = new CustomModelDataItemConfig(this.configuration);
+        this.itemDamage = new ItemDamageItemConfig(this.configuration);
+        this.displayName = new DisplayNameItemConfig(this.configuration);
+        this.dyeColour = new DyeColourItemConfig(this.configuration);
+        this.glowing = new GlowingItemConfig(this.configuration);
+        this.lore = new LoreItemConfig(this.configuration);
+        this.potionMeta = new PotionMetaItemConfig(this.configuration);
 
         this.baseItem = getBaseItem();
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/items/configs/ItemConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/items/configs/ItemConfig.java
@@ -20,8 +20,14 @@ public abstract class ItemConfig<T> {
     }
 
     public T getActualValue() {
-        T val = override == null ? getConfiguredValue() : override;
-        return val == null ? def : val;
+        if (override != null) {
+            return override;
+        }
+        T configured = getConfiguredValue();
+        if (configured == null) {
+            return def;
+        }
+        return configured;
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes the Journal menu's items

---

### What has changed?
- Now uses `this.configuration` when constructing the ItemConfig classes. :facepalm: 
- Renamed the ItemFactory constructor's `configuration` variable to `initialSection`.

---

### Related Issues
Closes #670

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.