### PR TITLE
Add enchantment config to ItemFactory

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -419,12 +419,7 @@ public class FishUtils {
     }
 
     public static @Nullable Biome getBiome(@NotNull String keyString) {
-        // Force lowercase
         keyString = keyString.toLowerCase();
-        // If no namespace, assume minecraft
-        if (!keyString.contains(":")) {
-            keyString = "minecraft:" + keyString;
-        }
         // Get the key and check if null
         NamespacedKey key = NamespacedKey.fromString(keyString);
         if (key == null) {
@@ -727,14 +722,12 @@ public class FishUtils {
     }
 
     public static Enchantment getEnchantment(@NotNull String namespace) {
-        Registry<Enchantment> registry = Registry.ENCHANTMENT;
+        namespace = namespace.toLowerCase();
         NamespacedKey key = NamespacedKey.fromString(namespace);
         if (key == null) {
-            System.out.println("Key invalid");
             return null;
         }
-        System.out.println(key);
-        return registry.get(key);
+        return Registry.ENCHANTMENT.get(key);
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -40,6 +40,7 @@ import org.bukkit.Registry;
 import org.bukkit.Sound;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Skull;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -723,6 +724,17 @@ public class FishUtils {
             amplifier - 1,
             false
         );
+    }
+
+    public static Enchantment getEnchantment(@NotNull String namespace) {
+        Registry<Enchantment> registry = Registry.ENCHANTMENT;
+        NamespacedKey key = NamespacedKey.fromString(namespace);
+        if (key == null) {
+            System.out.println("Key invalid");
+            return null;
+        }
+        System.out.println(key);
+        return registry.get(key);
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/items/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/items/ItemFactory.java
@@ -6,6 +6,7 @@ import com.oheers.fish.config.ConfigUtils;
 import com.oheers.fish.items.configs.CustomModelDataItemConfig;
 import com.oheers.fish.items.configs.DisplayNameItemConfig;
 import com.oheers.fish.items.configs.DyeColourItemConfig;
+import com.oheers.fish.items.configs.EnchantmentsItemConfig;
 import com.oheers.fish.items.configs.GlowingItemConfig;
 import com.oheers.fish.items.configs.ItemDamageItemConfig;
 import com.oheers.fish.items.configs.LoreItemConfig;
@@ -43,6 +44,7 @@ public class ItemFactory {
     private final GlowingItemConfig glowing;
     private final LoreItemConfig lore;
     private final PotionMetaItemConfig potionMeta;
+    private final EnchantmentsItemConfig enchantments;
 
     private ItemFactory(@NotNull Section initialSection, @Nullable String configLocation) {
         if (configLocation == null) {
@@ -61,6 +63,7 @@ public class ItemFactory {
         this.glowing = new GlowingItemConfig(this.configuration);
         this.lore = new LoreItemConfig(this.configuration);
         this.potionMeta = new PotionMetaItemConfig(this.configuration);
+        this.enchantments = new EnchantmentsItemConfig(this.configuration);
 
         this.baseItem = getBaseItem();
     }
@@ -99,6 +102,7 @@ public class ItemFactory {
             glowing.apply(item, replacements);
             lore.apply(item, replacements);
             potionMeta.apply(item, replacements);
+            enchantments.apply(item, replacements);
 
             if (finalChanges != null) {
                 finalChanges.accept(item);
@@ -210,6 +214,10 @@ public class ItemFactory {
 
     public PotionMetaItemConfig getPotionMeta() {
         return potionMeta;
+    }
+
+    public EnchantmentsItemConfig getEnchantments() {
+        return enchantments;
     }
 
     // Base Item Methods //

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/items/configs/EnchantmentsItemConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/items/configs/EnchantmentsItemConfig.java
@@ -1,0 +1,56 @@
+package com.oheers.fish.items.configs;
+
+import com.oheers.fish.FishUtils;
+import com.oheers.fish.utils.Pair;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class EnchantmentsItemConfig extends ItemConfig<Map<Enchantment, @NotNull Integer>> {
+
+    public EnchantmentsItemConfig(@NotNull Section section) {
+        super(section);
+    }
+
+    @Override
+    public Map<Enchantment, @NotNull Integer> getConfiguredValue() {
+        List<String> strings = section.getStringList("item.enchantments");
+        if (strings.isEmpty()) {
+            return Map.of();
+        }
+        Map<Enchantment, Integer> enchantments = new HashMap<>();
+        for (String string : strings) {
+            Pair<Enchantment, Integer> parsed = parseEnchantment(string);
+            enchantments.put(parsed.getLeft(), parsed.getRight());
+        }
+        return enchantments;
+    }
+
+    private Pair<Enchantment, Integer> parseEnchantment(@NotNull String string) {
+        String[] split = string.split(",");
+        String name = split[0];
+        Enchantment enchantment = FishUtils.getEnchantment(name);
+        if (split.length == 1) {
+            return new Pair<>(enchantment, 1);
+        } else {
+            Integer level = FishUtils.getInteger(split[1]);
+            if (level == null) {
+                level = 1;
+            }
+            return new Pair<>(enchantment, level);
+        }
+    }
+
+    @Override
+    protected BiConsumer<ItemStack, Map<Enchantment, @NotNull Integer>> applyToItem(@Nullable Map<String, ?> replacements) {
+        return ItemStack::addUnsafeEnchantments;
+    }
+
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/Pair.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/Pair.java
@@ -1,0 +1,29 @@
+package com.oheers.fish.utils;
+
+public class Pair<L, R> {
+
+    private L left;
+    private R right;
+
+    public Pair(L left, R right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public L getLeft() {
+        return left;
+    }
+
+    public void setLeft(L left) {
+        this.left = left;
+    }
+
+    public R getRight() {
+        return right;
+    }
+
+    public void setRight(R right) {
+        this.right = right;
+    }
+
+}


### PR DESCRIPTION
## Description
Adds the ability to add enchantments via ItemFactory.

This supports custom enchantments on 1.21+ (as that is when data-driven enchantments were added):
```
enchantments:
  - lure,3
  # The first custom enchantment plugin I could find
  - veinminer-enchantment:veinminer,1
```

---

### What has changed?
- Added EnchantmentsItemConfig
- Added Pair class
- Added FishUtils#getEnchantment
- Cleaned up FishUtils#getBiome

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.