### PR TITLE
Restrict bait application to the player's inventory

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitListener.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitListener.java
@@ -21,6 +21,7 @@ import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 
 public class BaitListener implements Listener {
 
@@ -29,11 +30,13 @@ public class BaitListener implements Listener {
         ItemStack potentialFishingRod = event.getCurrentItem();
         ItemStack cursor = event.getCursor();
 
-        if (potentialFishingRod == null) {
+        // Check anvil protection first
+        if (MainConfig.getInstance().shouldProtectBaitedRods() && anvilCheck(event)) {
             return;
         }
 
-        if (MainConfig.getInstance().shouldProtectBaitedRods() && anvilCheck(event)) {
+        // Check if we need to continue applying a bait
+        if (!BaitNBTManager.isBaitObject(cursor) || potentialFishingRod == null || !(event.getClickedInventory() instanceof PlayerInventory)) {
             return;
         }
 
@@ -45,10 +48,6 @@ public class BaitListener implements Listener {
         // Tell the player if the rod is invalid
         if (!Checks.canUseRod(potentialFishingRod)) {
             ConfigMessage.BAIT_INVALID_ROD.getMessage().send(event.getWhoClicked());
-            return;
-        }
-
-        if (!BaitNBTManager.isBaitObject(cursor)) {
             return;
         }
 

--- a/even-more-fish-plugin/src/main/resources/rarities/_example.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/_example.yml
@@ -96,6 +96,14 @@ fish:
       lore:
         - <gray>Hola!
 
+      # Customize this item's enchantments.
+      # This supports custom enchantments if you use their namespace.
+      enchantments:
+        # Add lure 3
+        - lure,3
+        # Add veinminer
+        - veinminer-enchantment:veinminer,1
+
     # The catch type for this fish. This overrides the rarity's value.
     catch-type: BOTH
 


### PR DESCRIPTION
## Description
Baits can no longer be applied outside of the player's inventory

---

### What has changed?
- Added a check for the clicked inventory being a player inventory in BaitListener

---

### Related Issues
Reported on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.