### PR TITLE
NPE Fixes

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -590,7 +591,7 @@ public class Competition {
                 this.selectedRarity = rarity;
                 return true;
             }
-            this.selectedRarity = FishManager.getInstance().getRandomWeightedRarity(null, 0, null, Set.copyOf(FishManager.getInstance().getRarityMap().values()), null);
+            this.selectedRarity = FishManager.getInstance().getRandomWeightedRarity(null, 0, Collections.emptySet(), Set.copyOf(FishManager.getInstance().getRarityMap().values()), null);
             return true;
         } catch (IllegalArgumentException exception) {
             EvenMoreFish.getInstance()

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -24,7 +24,9 @@ public class FishingProcessor extends Processor<PlayerFishEvent> {
     @Override
     @EventHandler(priority = EventPriority.HIGHEST)
     public void process(@NotNull PlayerFishEvent event) {
-        if (!isCustomFishAllowed(event.getPlayer()) || !Checks.canUseRod(getRod(event))) {
+        ItemStack rod = getRod(event);
+
+        if (!isCustomFishAllowed(event.getPlayer()) || !Checks.canUseRod(rod)) {
             return;
         }
 
@@ -39,7 +41,7 @@ public class FishingProcessor extends Processor<PlayerFishEvent> {
             return;
         }
 
-        ItemStack fish = getFish(event.getPlayer(), event.getHook().getLocation(), event.getPlayer().getInventory().getItemInMainHand());
+        ItemStack fish = getFish(event.getPlayer(), event.getHook().getLocation(), rod);
 
         if (fish == null) {
             return;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/Processor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/Processor.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.DecimalFormat;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -58,7 +59,7 @@ public abstract class Processor<E extends Event> implements Listener {
             return bait.chooseFish(player, location);
         }
 
-        final Rarity fishRarity = FishManager.getInstance().getRandomWeightedRarity(player, 1, null, Set.copyOf(FishManager.getInstance().getRarityMap().values()), customRod);
+        final Rarity fishRarity = FishManager.getInstance().getRandomWeightedRarity(player, 1, Collections.emptySet(), Set.copyOf(FishManager.getInstance().getRarityMap().values()), customRod);
         if (fishRarity == null) {
             EvenMoreFish.getInstance().getLogger().severe("Could not determine a rarity for fish for " + player.getName());
             return null;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/FishManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/FishManager.java
@@ -88,7 +88,7 @@ public class FishManager {
         return rarity.getFish(fishName);
     }
 
-    public Rarity getRandomWeightedRarity(Player fisher, double boostRate, Set<Rarity> boostedRarities, Set<Rarity> totalRarities, @Nullable CustomRod customRod) {
+    public Rarity getRandomWeightedRarity(Player fisher, double boostRate, @NotNull Set<Rarity> boostedRarities, Set<Rarity> totalRarities, @Nullable CustomRod customRod) {
         if (fisher != null) {
             Map<UUID, Rarity> decidedRarities = EvenMoreFish.getInstance().getDecidedRarities();
             if (decidedRarities.containsKey(fisher.getUniqueId())) {
@@ -204,7 +204,7 @@ public class FishManager {
 
         // Protection against /emf admin reload causing the plugin to be unable to get the rarity
         if (r.getOriginalFishList().isEmpty()) {
-            r = getRandomWeightedRarity(p, 1, null, Set.copyOf(rarityMap.values()), customRod);
+            r = getRandomWeightedRarity(p, 1, Collections.emptySet(), Set.copyOf(rarityMap.values()), customRod);
         }
 
         List<Fish> customRodFish = customRod == null ? List.of() : customRod.getAllowedFish();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
@@ -201,6 +201,7 @@ public class FishJournalGui extends ConfigGui {
                     meta.displayName(display.getComponentMessage());
                 }
                 meta.lore(configuredMeta.lore());
+                meta.setCustomModelData(configuredMeta.getCustomModelData());
             });
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/WeightedRandom.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/WeightedRandom.java
@@ -26,7 +26,7 @@ public final class WeightedRandom {
             @NotNull List<T> elements,
             ToDoubleFunction<T> weightFunction,
             double boostRate,
-            Set<T> boosted,
+            @NotNull Set<T> boosted,
             @Nullable Random random
     ) {
         if (elements.isEmpty()) return null;
@@ -54,7 +54,7 @@ public final class WeightedRandom {
     }
 
     private static <T> double calcTotalWeight(@NotNull List<T> elements, ToDoubleFunction<T> weightFunction, double boostRate,
-                                       Set<T> boosted) {
+                                       @NotNull Set<T> boosted) {
         double totalWeight = 0.0;
         for (T element : elements) {
             double weight = weightFunction.applyAsDouble(element);


### PR DESCRIPTION
## Description
Fixes some NPEs

---

### What has changed?
- WeightedRandom now requires a non-null boosted set, the old usages of null were replaced with an empty set.
- Fixed an NPE in FishingProcessor related to not checking the correct rod item.
- Fixed CustomModelData in Journal rarity items

---

### Related Issues
Reported on Discord.

---

### Checklist

- [X]  I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.