### PR TITLE
Configuration must be loaded before dependecies

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -125,11 +125,11 @@ public class EvenMoreFish extends EMFPlugin {
 
         this.logger = getLogger();
 
-        this.dependencyManager = new DependencyManager(this);
-        this.dependencyManager.checkDependencies(); // need to test, order may be important, if it is, we introduce multiple stages with events
-
         this.configurationManager = new ConfigurationManager(this);
         this.configurationManager.loadConfigurations(); //need to test, order may be important
+
+        this.dependencyManager = new DependencyManager(this);
+        this.dependencyManager.checkDependencies(); // need to test, order may be important, if it is, we introduce multiple stages with events
 
         this.integrationManager = new IntegrationManager(this);
         this.integrationManager.loadAddons();


### PR DESCRIPTION
## Description
Configuration must be loaded before dependecies
---

### What has changed?
Configuration must be loaded before dependecies

---

### Related Issues
Link related issues or describe which problem this PR fixes.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.