### PR TITLE
Improve default configs

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -52,6 +52,7 @@ import java.util.logging.Logger;
 import static com.oheers.fish.FishUtils.classExists;
 
 public class EvenMoreFish extends EMFPlugin {
+
     private final Random random = new Random();
     private final boolean isPaper = classExists("com.destroystokyo.paper.PaperConfig")
         || classExists("io.papermc.paper.configuration.Configuration");
@@ -60,7 +61,6 @@ public class EvenMoreFish extends EMFPlugin {
     private boolean raritiesCompCheckExempt = false;
     private CompetitionQueue competitionQueue;
     private Logger logger;
-    private boolean firstLoad = false;
 
     // this is for pre-deciding a rarity and running particles if it will be chosen
     // it's a work-in-progress solution and probably won't stick.
@@ -112,9 +112,6 @@ public class EvenMoreFish extends EMFPlugin {
 
         CommandAPI.onEnable();
 
-        // If EMF folder does not exist, this is the first load.
-        firstLoad = !getDataFolder().exists();
-
         scheduler = UniversalScheduler.getScheduler(this);
 
         this.api = new EMFAPI();
@@ -138,17 +135,18 @@ public class EvenMoreFish extends EMFPlugin {
         }
 
         FishManager.getInstance().load();
+
+        // Always load this after FishManager
         BaitManager.getInstance().load();
 
-        // Always load this after FishManager and BaitManager
+        // Always load this after BaitManager
         RodManager.getInstance().load();
 
         competitionQueue = new CompetitionQueue();
         competitionQueue.load();
 
-        // check for updates on the modrinth page
+        // check for updates on the Modrinth page
         new UpdateChecker(this).checkUpdate().thenAccept(available -> isUpdateAvailable = available);
-
 
         this.metricsManager = new MetricsManager(this);
         this.metricsManager.setupMetrics();
@@ -163,9 +161,6 @@ public class EvenMoreFish extends EMFPlugin {
         registerCommands();
 
         logger.log(Level.INFO, "EvenMoreFish by Oheers : Enabled");
-
-        // Set this to false as the plugin is now loaded.
-        firstLoad = false;
     }
 
     @Override
@@ -220,9 +215,6 @@ public class EvenMoreFish extends EMFPlugin {
     @Override
     public void reload(@Nullable CommandSender sender) {
 
-        // If EMF folder does not exist, assume first load again.
-        firstLoad = !getDataFolder().exists();
-
         terminateGuis();
 
         this.configurationManager.reloadConfigurations();
@@ -242,8 +234,7 @@ public class EvenMoreFish extends EMFPlugin {
         if (sender != null) {
             ConfigMessage.RELOAD_SUCCESS.getMessage().send(sender);
         }
-
-        firstLoad = false;
+        
     }
 
     private void registerCommands() {
@@ -314,10 +305,6 @@ public class EvenMoreFish extends EMFPlugin {
         return pdc.getOrDefault(key, PersistentDataType.BOOLEAN, false);
     }
 
-    public boolean isFirstLoad() {
-        return firstLoad;
-    }
-
     public DependencyManager getDependencyManager() {
         return dependencyManager;
     }
@@ -325,6 +312,7 @@ public class EvenMoreFish extends EMFPlugin {
     public PluginDataManager getPluginDataManager() {
         return pluginDataManager;
     }
+
     public EventManager getEventManager() {
         return eventManager;
     }
@@ -332,4 +320,5 @@ public class EvenMoreFish extends EMFPlugin {
     public MetricsManager getMetricsManager() {
         return metricsManager;
     }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitManager.java
@@ -93,7 +93,7 @@ public class BaitManager {
         baitMap.clear();
 
         File baitsFolder = new File(EvenMoreFish.getInstance().getDataFolder(), "baits");
-        if (EvenMoreFish.getInstance().isFirstLoad()) {
+        if (!baitsFolder.exists()) {
             loadDefaultFiles(baitsFolder);
         }
         regenExampleFile(baitsFolder);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
@@ -38,7 +38,7 @@ public class CompetitionQueue {
         fileMap.clear();
 
         File compsFolder = new File(EvenMoreFish.getInstance().getDataFolder(), "competitions");
-        if (EvenMoreFish.getInstance().isFirstLoad()) {
+        if (!compsFolder.exists()) {
             loadDefaultFiles(compsFolder);
         }
         regenExampleFile(compsFolder);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/FishManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/FishManager.java
@@ -268,7 +268,7 @@ public class FishManager {
         rarityMap.clear();
 
         File raritiesFolder = new File(EvenMoreFish.getInstance().getDataFolder(), "rarities");
-        if (EvenMoreFish.getInstance().isFirstLoad()) {
+        if (!raritiesFolder.exists()) {
             loadDefaultFiles(raritiesFolder);
         }
         regenExampleFile(raritiesFolder);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/rods/RodManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/rods/RodManager.java
@@ -90,7 +90,7 @@ public class RodManager {
 
     private void loadRods() {
         File rodsFolder = new File(EvenMoreFish.getInstance().getDataFolder(), "rods");
-        if (EvenMoreFish.getInstance().isFirstLoad()) {
+        if (!rodsFolder.exists()) {
             loadDefaultFiles(rodsFolder);
         }
         regenExampleFile(rodsFolder);


### PR DESCRIPTION
## Description
Improves how default configs are loaded

---

### What has changed?
- Default configs are now loaded when their respective folder is missing instead of the plugin folder.
- Removed EvenMoreFish#isFirstLoad

---

### Related Issues
N/A

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.