### PR TITLE
Fixes issue with renovate & jooq

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,8 @@
     },
     {
       "matchPackagePrefixes": ["org.jooq:"],
-      "groupName": "jOOQ"
+      "groupName": "jOOQ",
+      "allowedVersions": "~3.19.0"
     },
 
     {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -83,7 +83,7 @@ dependencyResolutionManagement {
 
             plugin("grgit", "org.ajoberstar.grgit").version("5.3.2")
 
-            version("jooq", "3.20.5")
+            version("jooq", "3.19.24")
             library("jooq", "org.jooq","jooq").versionRef("jooq")
             library("jooq-codegen", "org.jooq", "jooq-codegen").versionRef("jooq")
             library("jooq-meta", "org.jooq", "jooq-meta").versionRef("jooq")


### PR DESCRIPTION
## Description
Fixes issue with renovate & jooq.

---

### What has changed?
Jooq 3.20 only support JDK 21. 
I added a limit to renovate to not update beyond 3.19.X. We should still get patch updates.

---

### Related Issues
Link related issues or describe which problem this PR fixes.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.