### PR TITLE
Update some things

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
@@ -337,7 +337,7 @@ public class Bait extends ConfigBase {
             EvenMoreFish.getInstance().getMetricsManager().incrementBaitsUsed(1);
         } catch (MaxBaitReachedException | MaxBaitsReachedException e) {
             logger.log(Level.WARNING, e.getMessage());
-            player.sendMessage(e.getConfigMessage().getMessage().getComponentMessage());
+            player.sendMessage(e.getConfigMessage().getMessage().getComponentMessage(player));
         } catch (NullPointerException exception) {
             logger.log(Level.SEVERE, exception.getMessage(), exception);
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -499,6 +499,10 @@ public class AdminCommand {
         return new CommandAPICommand("rawItem")
                 .executesPlayer(info -> {
                     ItemStack handItem = info.sender().getInventory().getItemInMainHand();
+                    if (handItem.isEmpty()) {
+                        return;
+                    }
+
                     String handItemNbt = NBT.itemStackToNBT(handItem).toString();
 
                     // Ensure the handItemNbt is escaped for use in YAML
@@ -512,7 +516,6 @@ public class AdminCommand {
                     builder.clickEvent(ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, handItemNbt));
                     info.sender().sendMessage(builder.build());
                 });
-
     }
 
     private CommandAPICommand getHelp() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -327,7 +327,6 @@ public class Fish {
 
         if (!disableFisherman && getFishermanPlayer() != null) {
             newLoreLine.setVariable("{fisherman_lore}", ConfigMessage.FISHERMAN_LORE.getMessage().toListMessage());
-            newLoreLine.setPlayer(getFishermanPlayer());
         } else {
             newLoreLine.setVariable("{fisherman_lore}", EMFListMessage.empty());
         }
@@ -341,13 +340,11 @@ public class Fish {
 
         newLoreLine.setRarity(this.rarity.getLorePrep());
 
-        OfflinePlayer fisherman = getFishermanPlayer();
-        if (fisherman != null) {
-            newLoreLine.setPlayer(fisherman);
-            newLoreLine.formatPlaceholderAPI();
+        if (disableFisherman) {
+            return newLoreLine.getComponentListMessage();
+        } else {
+            return newLoreLine.getComponentListMessage(getFishermanPlayer());
         }
-
-        return newLoreLine.getComponentListMessage();
     }
 
     public void checkEatEvent() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/rods/RodConversion.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/rods/RodConversion.java
@@ -46,7 +46,6 @@ public class RodConversion {
         YamlDocument config = configBase.getConfig();
 
         config.set("id", "default");
-        config.set("disabled", !MainConfig.getInstance().getConfig().getBoolean("require-nbt-rod"));
         config.set("allowed-rarities", "ALL");
         config.set("item", section.get("item"));
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
@@ -96,9 +96,9 @@ public class FishJournalGui extends ConfigGui {
             ItemFactory factory = ItemFactory.itemFactory(section, "fish-item");
             EMFSingleMessage display = prepareDisplay(factory, fish);
             if (display != null) {
-                meta.displayName(display.getComponentMessage());
+                meta.displayName(display.getComponentMessage(player));
             }
-            meta.lore(prepareLore(factory, fish).getComponentListMessage());
+            meta.lore(prepareLore(factory, fish).getComponentListMessage(player));
         });
 
         return item;
@@ -198,7 +198,7 @@ public class FishJournalGui extends ConfigGui {
                 if (configuredDisplay != null) {
                     EMFSingleMessage display = EMFSingleMessage.of(configuredDisplay);
                     display.setRarity(rarity.getDisplayName());
-                    meta.displayName(display.getComponentMessage());
+                    meta.displayName(display.getComponentMessage(player));
                 }
                 meta.lore(configuredMeta.lore());
                 if (configuredMeta.hasCustomModelData()) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -9,6 +9,8 @@ import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -70,12 +72,36 @@ public class EMFListMessage extends EMFMessage {
 
     @Override
     public void send(@NotNull Audience target) {
-        target.sendMessage(getComponentMessage());
+        if (isEmpty()) {
+            return;
+        }
+        List<Component> message = (target instanceof Player player) ?
+            getComponentListMessage(player) :
+            getComponentListMessage();
+
+        message.forEach(part -> {
+            if (silentCheck(part)) {
+                return;
+            }
+            target.sendMessage(part);
+        });
     }
 
     @Override
     public void sendActionBar(@NotNull Audience target) {
-        target.sendActionBar(getComponentMessage());
+        if (isEmpty()) {
+            return;
+        }
+
+        Component message = (target instanceof Player player) ?
+            getComponentMessage(player) :
+            getComponentMessage();
+
+        if (silentCheck(message)) {
+            return;
+        }
+
+        target.sendActionBar(message);
     }
 
     /**
@@ -87,13 +113,25 @@ public class EMFListMessage extends EMFMessage {
 
     @Override
     public @NotNull Component getComponentMessage() {
-        return Component.join(JoinConfiguration.newlines(), getComponentListMessage());
+        return getComponentMessage(null);
+    }
+
+    @Override
+    public @NotNull Component getComponentMessage(@Nullable OfflinePlayer player) {
+        return Component.join(JoinConfiguration.newlines(), getComponentListMessage(player));
     }
 
     @Override
     public @NotNull List<Component> getComponentListMessage() {
-        formatPlaceholderAPI();
-        return this.message.stream()
+        return getComponentListMessage(null);
+    }
+
+    @Override
+    public @NotNull List<Component> getComponentListMessage(@Nullable OfflinePlayer player) {
+        EMFListMessage copy = createCopy();
+        copy.setPlayer(player);
+        copy.formatPlaceholderAPI();
+        return copy.message.stream()
             .map(EMFMessage::removeDefaultItalics)
             .map(component -> component.colorIfAbsent(NamedTextColor.WHITE))
             .toList();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -37,7 +37,11 @@ public class EMFListMessage extends EMFMessage {
 
     @Override
     public EMFListMessage createCopy() {
-        return toListMessage();
+        EMFListMessage message = EMFListMessage.ofList(this.message);
+        message.perPlayer = this.perPlayer;
+        message.canSilent = this.canSilent;
+        message.relevantPlayer = this.relevantPlayer;
+        return message;
     }
 
     // Factory methods

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
@@ -31,7 +31,11 @@ public class EMFSingleMessage extends EMFMessage {
 
     @Override
     public EMFSingleMessage createCopy() {
-        return toSingleMessage();
+        EMFSingleMessage message = EMFSingleMessage.of(this.message);
+        message.perPlayer = this.perPlayer;
+        message.canSilent = this.canSilent;
+        message.relevantPlayer = this.relevantPlayer;
+        return message;
     }
 
     // Factory methods

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -75,13 +76,11 @@ public class EMFSingleMessage extends EMFMessage {
             return;
         }
 
-        EMFSingleMessage copy = createCopy();
+        Component message = (audience instanceof Player player) ?
+            getComponentMessage(player) :
+            getComponentMessage();
 
-        if (perPlayer && audience instanceof Player player) {
-            copy.setPlayer(player);
-        }
-
-        audience.sendMessage(copy.getComponentMessage());
+        audience.sendMessage(message);
     }
 
     public void sendActionBar(@NotNull Audience audience) {
@@ -89,13 +88,11 @@ public class EMFSingleMessage extends EMFMessage {
             return;
         }
 
-        EMFSingleMessage copy = createCopy();
+        Component message = (audience instanceof Player player) ?
+            getComponentMessage(player) :
+            getComponentMessage();
 
-        if (perPlayer && audience instanceof Player player) {
-            copy.setPlayer(player);
-        }
-
-        audience.sendActionBar(copy.getComponentMessage());
+        audience.sendActionBar(message);
     }
 
     /**
@@ -105,18 +102,22 @@ public class EMFSingleMessage extends EMFMessage {
         return this.message;
     }
 
-    /**
-     * @return The stored Component with all variables applied..
-     */
     @Override
-    public @NotNull Component getComponentMessage() {
-        formatPlaceholderAPI();
-        return removeDefaultItalics(this.message).colorIfAbsent(NamedTextColor.WHITE);
+    public @NotNull Component getComponentMessage(@Nullable OfflinePlayer player) {
+        EMFSingleMessage copy = createCopy();
+        copy.setPlayer(player);
+        copy.formatPlaceholderAPI();
+        return removeDefaultItalics(copy.message).colorIfAbsent(NamedTextColor.WHITE);
     }
 
     @Override
     public @NotNull List<Component> getComponentListMessage() {
         return List.of(getComponentMessage());
+    }
+
+    @Override
+    public @NotNull List<Component> getComponentListMessage(@Nullable OfflinePlayer player) {
+        return List.of(getComponentMessage(player));
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
@@ -68,9 +68,17 @@ public abstract class EMFMessage {
         targets.forEach(this::sendActionBar);
     }
 
-    public abstract @NotNull Component getComponentMessage();
+    public @NotNull Component getComponentMessage() {
+        return getComponentMessage(null);
+    }
 
-    public abstract @NotNull List<Component> getComponentListMessage();
+    public abstract @NotNull Component getComponentMessage(@Nullable OfflinePlayer player);
+
+    public @NotNull List<Component> getComponentListMessage() {
+        return getComponentListMessage(null);
+    }
+
+    public abstract @NotNull List<Component> getComponentListMessage(@Nullable OfflinePlayer player);
 
     public @NotNull String getLegacyMessage() {
         return LEGACY_SERIALIZER.serialize(getComponentMessage());
@@ -207,7 +215,10 @@ public abstract class EMFMessage {
      *
      * @param player The player.
      */
-    public void setPlayer(@NotNull final OfflinePlayer player) {
+    public void setPlayer(@Nullable final OfflinePlayer player) {
+        if (player == null) {
+            return;
+        }
         this.relevantPlayer = player;
         setVariable("{player}", Objects.requireNonNullElse(player.getName(), "N/A"));
     }


### PR DESCRIPTION
### What has changed?
- The converted custom rod is now always enabled. This is a safe change as it won't have a recipe.
- We now check for an empty hand in the rawItem admin command.
- `EMFMessage#getComponent(List)Message` now creates a copy instead of `#send`

---

### Related Issues
Closes #730
~~Resolves half of #686~~

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.