### PR TITLE
Introduce an option to only override caught fish

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -39,7 +39,6 @@ public class MainConfig extends ConfigBase {
     private final String applyBaitsSubCommandName;
     private final String journalSubCommandName;
 
-
     public MainConfig() {
         super("config.yml", "config.yml", EvenMoreFish.getInstance(), true);
         instance = this;
@@ -87,6 +86,10 @@ public class MainConfig extends ConfigBase {
 
     public boolean isFishCatchOnlyInCompetition() {
         return getConfig().getBoolean("fishing.catch-only-in-competition", false);
+    }
+
+    public boolean isFishCatchOverrideOnlyFish() {
+        return getConfig().getBoolean("fishing.only-fish", false);
     }
 
     public boolean isHuntEnabled() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -10,6 +10,7 @@ import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.messages.ConfigMessage;
 import com.oheers.fish.permissions.UserPerms;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -59,19 +60,20 @@ public class FishingProcessor extends Processor<PlayerFishEvent> {
             return;
         }
 
-        if (rod == null) {
-            plugin.debug("Null rod, somehow.");
+        if (!(event.getCaught() instanceof Item nonCustom)) {
+            plugin.debug("Caught entity is not an Item.");
             return;
         }
+
+        if (MainConfig.getInstance().isFishCatchOverrideOnlyFish() && !Tag.ITEMS_FISHES.isTagged(nonCustom.getItemStack().getType())) {
+            plugin.debug("Caught item is not a vanilla fish, and we have been told to skip non-fish. Skipping.");
+            return;
+        }
+
         ItemStack fish = getFish(event.getPlayer(), event.getHook().getLocation(), rod);
 
         if (fish == null) {
             plugin.debug("Could not obtain fish.");
-            return;
-        }
-
-        if (!(event.getCaught() instanceof Item nonCustom)) {
-            plugin.debug("Caught entity is not an Item.");
             return;
         }
 

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -19,6 +19,8 @@ fishing:
   catch-only-in-competition: false
   # Should custom rods be required?
   require-custom-rod: false
+  # Should the plugin only override fish, keeping treasure like enchanted books?
+  only-fish: false
 
   # Should fish be caught by killing fish entities?
   hunt-enabled: false
@@ -253,5 +255,5 @@ biome-sets:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-version: 3
+version: 4
 


### PR DESCRIPTION
### What has changed?
- Added a new config: `fishing.only-fish`
  - If this is enabled, only fish items will be replaced with EMF fish, allowing vanilla treasure and junk to still be caught.

---

### Related Issues
Closes #776 

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.