### PR TITLE
Remove redundant `place-head-fish` config option

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/SkullSaver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/SkullSaver.java
@@ -67,7 +67,6 @@ public class SkullSaver implements Listener {
     
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlace(BlockPlaceEvent event) {
-        
         if (event.isCancelled()) {
             return;
         }
@@ -80,11 +79,6 @@ public class SkullSaver implements Listener {
         }
         
         if (FishUtils.isFish(stack)) {
-            if (MainConfig.getInstance().blockPlacingHeads()) {
-                event.setCancelled(true);
-                ConfigMessage.FISH_CANT_BE_PLACED.getMessage().send(event.getPlayer());
-                return;
-            }
             
             if (block.getState() instanceof Skull sm) {
                 Fish fish = FishUtils.getFish(stack);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -153,10 +153,6 @@ public class MainConfig extends ConfigBase {
         return !getConfig().getBoolean("disable-db-verbose", false);
     }
 
-    public boolean blockPlacingHeads() {
-        return getConfig().getBoolean("place-head-fish", false);
-    }
-
     public boolean requireCustomRod() {
         return getConfig().getBoolean("fishing.require-custom-rod", false);
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/ConfigMessage.java
@@ -66,7 +66,6 @@ public enum ConfigMessage {
 
     ECONOMY_DISABLED("<white>EvenMoreFish's economy features are disabled.", PrefixType.ERROR, false, false, "admin.economy-disabled"),
 
-    FISH_CANT_BE_PLACED("<white>You cannot place this fish.", PrefixType.ERROR, true, true, "place-fish-blocked"),
     FISH_CAUGHT("<white><b>{player}</b> has fished a {length}cm <b>{rarity}</b> {fish}!", PrefixType.NONE, true, true, "fish-caught"),
     FISH_LENGTHLESS_CAUGHT("<white><b>{player}</b> has fished a <b>{rarity}</b> {fish}!", PrefixType.NONE, true, true, "lengthless-fish-caught"),
     FISH_HUNTED("<white><b>{player}</b> has hunted a {length}cm <bold>{rarity}</bold> {fish}!", PrefixType.NONE, true, true, "fish-hunted"),

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -161,9 +161,6 @@ disable-mcmmo-loot: true
 # Prevents AureliumSkills from overriding fishing loot, this means treasure won't appear when fish can.
 disable-aureliumskills-loot: true
 
-# When set to true, players won't be able to place fish that are heads, like head-64 or head-uuid.
-place-head-fish: false
-
 # Whether to protect baited fishing rods in an anvil.
 protect-baited-rods: true
 

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -212,9 +212,6 @@ bait-invalid-rod: <white>You cannot apply bait to this fishing rod!
 toggle-off: <white>You will no longer catch custom fish.
 toggle-on: <white>You will now catch custom fish.
 
-# When trying to place a skull-fish when this is blocked in config.yml
-place-fish-blocked: <white>You cannot place this fish.
-
 admin:
   # Opens an /emf shop for another player
   open-fish-shop: <white>Opened a shop inventory for {player}.


### PR DESCRIPTION
### What has changed?
- Removed `place-head-fish` in config.yml.
  - This has been redundant for a while due to the new item-protection configs.
- Removed `place-fish-blocked` in messages.yml.
  - No longer required.

---

### Related Issues
Discovered on Discord

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.