### PR TITLE
Skip a help message if the description is empty

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/HelpMessageBuilder.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/HelpMessageBuilder.java
@@ -47,9 +47,13 @@ public class HelpMessageBuilder {
     public EMFMessage buildMessage() {
         final EMFListMessage message = ConfigMessage.HELP_GENERAL_TITLE.getMessage().toListMessage();
         usages.forEach((key, value) -> {
+            EMFMessage description = value.get();
+            if (description == null || description.isEmpty()) {
+                return;
+            }
             EMFMessage usage = ConfigMessage.HELP_FORMAT.getMessage();
             usage.setVariable("{command}", correctCommand(key));
-            usage.setVariable("{description}", value.get());
+            usage.setVariable("{description}", description);
             message.appendMessage(usage);
         });
         return message;


### PR DESCRIPTION
### What has changed?
- If a help message description is null or empty, we don't show that message.
  - This will allow server owners to hide specific messages if they wish.

---

### Related Issues
Requested on Discord.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.