### PR TITLE
Don't open the GUI if no permission

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
@@ -53,7 +53,7 @@ public class MainCommand {
                         new AdminCommand(adminName).getCommand()
                 )
                 .executesPlayer(info -> {
-                    if (MainConfig.getInstance().useOldBaseCommandBehavior()) {
+                    if (!info.sender().hasPermission(UserPerms.GUI) || MainConfig.getInstance().useOldBaseCommandBehavior()) {
                         sendHelpMessage(info.sender());
                     } else {
                         new MainMenuGui(info.sender()).open();

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -236,6 +236,7 @@ command:
     journal: "journal"
 
   # Should the base command show the help text instead of opening the GUI?
+  # This is always true if the player doesn't have the /emf gui permission.
   old-base-command-behavior: false
 
 # Customizable sets of biomes for fish configuration


### PR DESCRIPTION
### What has changed?
- The plugin GUI is no longer opened if the player doesn't have the `emf.gui` permission.
- Updated the config.yml comment to explain this.

---

### Related Issues
Closes #791 

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.