### PR TITLE
Use MessageLib library

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     alias(libs.plugins.shadow)
     alias(libs.plugins.grgit)
     alias(libs.plugins.jooq)
-    id("org.sonarqube") version "6.3.0.5676"
+    id("org.sonarqube") version "6.2.0.5505"
 }
 
 group = "com.oheers.evenmorefish"
@@ -106,6 +106,7 @@ dependencies {
     implementation(libs.inventorygui)
     implementation(libs.boostedyaml)
     implementation(libs.vanishchecker)
+    implementation(libs.messagelib)
     implementation(libs.universalscheduler)
 
     //temp fix until dynamic gradle plugin is ready ("mirror-aware-plugin") by sarhatabaot
@@ -288,8 +289,6 @@ tasks {
             val file = project.layout.buildDirectory.file("libs/even-more-fish-plugin-${version}.jar").get()
             file.asFile.delete()
         }
-
-
     }
 
     jooq {
@@ -342,6 +341,7 @@ tasks {
         relocate("com.github.Anon8281.universalScheduler", "com.oheers.fish.libs.universalScheduler")
         relocate("de.themoep.inventorygui", "com.oheers.fish.libs.inventorygui")
         relocate("uk.firedev.vanishchecker", "com.oheers.fish.libs.vanishchecker")
+        relocate("uk.firedev.messagelib", "com.oheers.fish.libs.messagelib")
         relocate("dev.dejvokep.boostedyaml", "com.oheers.fish.libs.boostedyaml")
         relocate("dev.jorel.commandapi", "com.oheers.fish.libs.commandapi")
         relocate("org.jooq", "com.oheers.fish.libs.jooq")

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -660,14 +660,6 @@ public class FishUtils {
         return EMFMessage.PLAINTEXT_SERIALIZER.serialize(component).contains(string);
     }
 
-    public static @NotNull Component decorateIfAbsent(@NotNull Component component, @NotNull TextDecoration decoration, @NotNull TextDecoration.State state) {
-        TextDecoration.State oldState = component.decoration(decoration);
-        if (oldState == TextDecoration.State.NOT_SET) {
-            return component.decoration(decoration, state);
-        }
-        return component;
-    }
-
     /**
      * @param colour The original colour
      * @return A string turned into a format key for use in configs.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -28,6 +28,7 @@ import com.oheers.fish.fishing.items.Rarity;
 import com.oheers.fish.fishing.rods.CustomRod;
 import com.oheers.fish.messages.ConfigMessage;
 import com.oheers.fish.messages.EMFSingleMessage;
+import com.oheers.fish.messages.PrefixType;
 import com.oheers.fish.messages.abstracted.EMFMessage;
 import com.oheers.fish.permissions.AdminPerms;
 import de.tr7zw.changeme.nbtapi.NBT;
@@ -425,7 +426,7 @@ public class AdminCommand {
 
                     EMFSingleMessage message = EMFSingleMessage.fromString(msgString);
 
-                    message.setVariable("{prefix}", MessageConfig.getInstance().getSTDPrefix());
+                    message.setVariable("{prefix}", PrefixType.DEFAULT.getPrefix());
                     message.setVariable("{version}", EvenMoreFish.getInstance().getPluginMeta().getVersion());
                     message.setVariable("{branch}", getFeatureBranchName());
                     message.setVariable("{build-date}", getFeatureBranchBuildOrDate());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MessageConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MessageConfig.java
@@ -1,6 +1,7 @@
 package com.oheers.fish.config;
 
 import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.messages.EMFConfigLoader;
 import com.oheers.fish.messages.EMFSingleMessage;
 import com.oheers.fish.messages.PrefixType;
 import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings;
@@ -9,13 +10,26 @@ public class MessageConfig extends ConfigBase {
 
     private static MessageConfig instance = null;
 
+    private EMFConfigLoader messageLoader;
+
     public MessageConfig() {
         super("messages.yml", "locales/" + "messages_" + MainConfig.getInstance().getLocale() + ".yml", EvenMoreFish.getInstance(), true);
         instance = this;
+        this.messageLoader = new EMFConfigLoader(getConfig());
     }
 
     public static MessageConfig getInstance() {
         return instance;
+    }
+
+    public EMFConfigLoader getMessageLoader() {
+        return messageLoader;
+    }
+
+    @Override
+    public void reload() {
+        super.reload();
+        this.messageLoader = new EMFConfigLoader(getConfig());
     }
 
     public EMFSingleMessage getSTDPrefix() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MessageConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MessageConfig.java
@@ -32,13 +32,6 @@ public class MessageConfig extends ConfigBase {
         this.messageLoader = new EMFConfigLoader(getConfig());
     }
 
-    public EMFSingleMessage getSTDPrefix() {
-        EMFSingleMessage message = EMFSingleMessage.empty();
-        message.prependMessage(PrefixType.DEFAULT.getPrefix());
-        message.appendString("<reset>");
-        return message;
-    }
-
     public int getLeaderboardCount() {
         return getConfig().getInt("leaderboard-count", 5);
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFConfigLoader.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFConfigLoader.java
@@ -1,0 +1,44 @@
+package com.oheers.fish.messages;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import uk.firedev.messagelib.config.ConfigLoader;
+
+import java.util.List;
+
+public class EMFConfigLoader implements ConfigLoader<Section> {
+
+    private final Section config;
+
+    public EMFConfigLoader(@NotNull Section section) {
+        this.config = section;
+    }
+    
+    @Override
+    public @Nullable Object getObject(String path) {
+        return config.get(path);
+    }
+
+    @Override
+    public @Nullable String getString(String path) {
+        return config.getString(path);
+    }
+
+    @Override
+    public @NotNull List<String> getStringList(String path) {
+        return config.getStringList(path);
+    }
+
+    @Override
+    public @NotNull Section getConfig() {
+        return config;
+    }
+
+    @Override
+    public @Nullable ConfigLoader<Section> getSection(@NotNull String path) {
+        Section section = config.getSection(path);
+        return section == null ? null : new EMFConfigLoader(section);
+    }
+    
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -13,106 +13,89 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import uk.firedev.messagelib.message.ComponentListMessage;
+import uk.firedev.messagelib.message.ComponentMessage;
+import uk.firedev.messagelib.message.ComponentSingleMessage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class EMFListMessage extends EMFMessage {
 
-    private ArrayList<Component> message = new ArrayList<>();
+    private ComponentListMessage underlying;
 
-    private EMFListMessage(@Nullable List<Component> message) {
+    private EMFListMessage(@NotNull ComponentListMessage message) {
         super();
-        if (message != null) {
-            message.forEach(line -> {
-                if (line == null) {
-                    return;
-                }
-                this.message.add(EMPTY.append(line));
-            });
-        }
+        this.underlying = message;
     }
 
     @Override
     public EMFListMessage createCopy() {
-        EMFListMessage message = EMFListMessage.ofList(this.message);
-        message.perPlayer = this.perPlayer;
-        message.canSilent = this.canSilent;
-        message.relevantPlayer = this.relevantPlayer;
-        return message;
+        EMFListMessage newMessage = new EMFListMessage(underlying.createCopy());
+        newMessage.perPlayer = this.perPlayer;
+        newMessage.canSilent = this.canSilent;
+        return newMessage;
+    }
+
+    @Override
+    public @NotNull ComponentListMessage getUnderlying() {
+        return underlying;
+    }
+
+    @Override
+    public void setUnderlying(@NotNull ComponentMessage message) {
+        if (message instanceof ComponentSingleMessage singleMessage) {
+            this.underlying = singleMessage.toListMessage();
+        } else if (message instanceof ComponentListMessage listMessage) {
+            this.underlying = listMessage;
+        } else {
+            // Should never happen.
+            return;
+        }
     }
 
     // Factory methods
 
     public static EMFListMessage empty() {
-        return new EMFListMessage(null);
+        return new EMFListMessage(
+            ComponentMessage.componentMessage(List.of())
+        );
     }
 
     public static EMFListMessage of(@NotNull Component component) {
-        return new EMFListMessage(List.of(component));
+        return new EMFListMessage(
+            ComponentMessage.componentMessage(List.of(component))
+        );
     }
 
     public static EMFListMessage ofList(@NotNull List<Component> components) {
-        if (components.isEmpty()) {
-            return empty();
-        }
-        return new EMFListMessage(components);
+        return new EMFListMessage(
+            ComponentMessage.componentMessage(components)
+        );
     }
 
     public static EMFListMessage fromString(@NotNull String string) {
-        return of(formatString(string));
+        return new EMFListMessage(
+            ComponentMessage.componentMessage(List.of(string))
+        );
     }
 
     public static EMFListMessage fromStringList(@NotNull List<String> strings) {
-        if (strings.isEmpty()) {
-            return empty();
-        }
-        return ofList(strings.stream().map(EMFListMessage::formatString).toList());
+        return new EMFListMessage(
+            ComponentMessage.componentMessage(strings)
+        );
     }
 
     // Class methods
-
-    @Override
-    public void send(@NotNull Audience target) {
-        if (isEmpty()) {
-            return;
-        }
-        List<Component> message = (target instanceof Player player) ?
-            getComponentListMessage(player) :
-            getComponentListMessage();
-
-        message.forEach(part -> {
-            if (silentCheck(part)) {
-                return;
-            }
-            target.sendMessage(part);
-        });
-    }
-
-    @Override
-    public void sendActionBar(@NotNull Audience target) {
-        if (isEmpty()) {
-            return;
-        }
-
-        Component message = (target instanceof Player player) ?
-            getComponentMessage(player) :
-            getComponentMessage();
-
-        if (silentCheck(message)) {
-            return;
-        }
-
-        target.sendActionBar(message);
-    }
 
     /**
      * @return The stored components in their original form, with no variables applied.
      */
     public @NotNull List<Component> getRawMessage() {
-        return this.message;
+        return this.underlying.get();
     }
 
     @Override
@@ -132,119 +115,24 @@ public class EMFListMessage extends EMFMessage {
 
     @Override
     public @NotNull List<Component> getComponentListMessage(@Nullable OfflinePlayer player) {
-        EMFListMessage copy = createCopy();
-        copy.setPlayer(player);
-        copy.formatPlaceholderAPI();
-        return copy.message.stream()
-            .map(EMFMessage::removeDefaultItalics)
-            .map(component -> component.colorIfAbsent(NamedTextColor.WHITE))
-            .toList();
+        return underlying.parsePlaceholderAPI(player)
+            .replace("{player}", Optional.ofNullable(player).map(OfflinePlayer::getName).orElse("null"))
+            .get();
     }
 
     @Override
     public void formatPlaceholderAPI() {
-        this.message = this.message.stream()
-            .map(line -> FishUtils.parsePlaceholderAPI(line, relevantPlayer))
-            .collect(Collectors.toCollection(ArrayList::new));
+        this.underlying = this.underlying.parsePlaceholderAPI(relevantPlayer);
     }
 
     @Override
     public boolean isEmpty() {
-        return message.isEmpty();
+        return underlying.isEmpty();
     }
 
     @Override
     public boolean containsString(@NotNull String string) {
-        return this.message.stream().anyMatch(line -> FishUtils.componentContainsString(line, string));
-    }
-
-    @Override
-    public void appendString(@NotNull String string) {
-        this.message.add(formatString(string));
-    }
-
-    @Override
-    public void appendMessage(@NotNull EMFMessage message) {
-        this.message.addAll(message.getComponentListMessage());
-    }
-
-    @Override
-    public void appendComponent(@NotNull Component component) {
-        this.message.add(component);
-    }
-
-    @Override
-    public void prependString(@NotNull String string) {
-        this.message.add(0, formatString(string));
-    }
-
-    @Override
-    public void prependMessage(@NotNull EMFMessage message) {
-        this.message.addAll(0, message.getComponentListMessage());
-    }
-
-    @Override
-    public void prependComponent(@NotNull Component component) {
-        this.message.add(0, component);
-    }
-
-    @Override
-    public void decorateIfAbsent(@NotNull TextDecoration decoration, TextDecoration.@NotNull State state) {
-        this.message = this.message.stream()
-            .map(line -> FishUtils.decorateIfAbsent(line, decoration, state))
-            .collect(Collectors.toCollection(ArrayList::new));
-    }
-
-    @Override
-    public void colorIfAbsent(@NotNull TextColor color) {
-        this.message = this.message.stream()
-            .map(line -> line.colorIfAbsent(color))
-            .collect(Collectors.toCollection(ArrayList::new));
-    }
-
-    /**
-     * Formats an EMFMessage replacement.
-     */
-    @Override
-    protected void setEMFMessageVariable(@NotNull String variable, @NotNull EMFMessage replacement) {
-        if (replacement instanceof EMFSingleMessage singleMessage) {
-            setComponentVariable(variable, singleMessage.getComponentMessage());
-        } else if (replacement instanceof EMFListMessage listMessage) {
-            formatListVariable(variable, listMessage);
-        }
-    }
-
-    /**
-     * Formats a Component replacement.
-     */
-    @Override
-    protected void setComponentVariable(@NotNull String variable, @NotNull Component replacement) {
-        TextReplacementConfig trc = TextReplacementConfig.builder()
-            .matchLiteral(variable)
-            .replacement(replacement)
-            .build();
-        this.message = this.message.stream()
-            .map(line -> line.replaceText(trc))
-            .collect(Collectors.toCollection(ArrayList::new));
-    }
-
-    private void formatListVariable(@NotNull String variable, @NotNull EMFListMessage replacement) {
-        this.message = this.message.stream()
-            .flatMap(line -> {
-                // If the variable is present in the line, replace it
-                if (FishUtils.componentContainsString(line, variable)) {
-                    // If the replacement is empty, return an empty stream to remove the line
-                    if (replacement.isEmpty()) {
-                        return Stream.empty();
-                    }
-                    return replacement.getComponentListMessage().stream();
-                // If not, return the original line
-                } else {
-                    return Stream.of(line);
-                }
-            })
-            // Ensure it's returned as an ArrayList
-            .collect(Collectors.toCollection(ArrayList::new));
+        return underlying.toSingleMessages().stream().anyMatch(singleMessage -> singleMessage.containsString(string));
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFListMessage.java
@@ -65,6 +65,10 @@ public class EMFListMessage extends EMFMessage {
         );
     }
 
+    public static EMFListMessage ofUnderlying(@NotNull ComponentListMessage underlying) {
+        return new EMFListMessage(underlying);
+    }
+
     public static EMFListMessage of(@NotNull Component component) {
         return new EMFListMessage(
             ComponentMessage.componentMessage(List.of(component))

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/EMFSingleMessage.java
@@ -27,7 +27,7 @@ public class EMFSingleMessage extends EMFMessage {
 
     private ComponentSingleMessage underlying;
 
-    private EMFSingleMessage(@NotNull ComponentSingleMessage message) {
+    protected EMFSingleMessage(@NotNull ComponentSingleMessage message) {
         super();
         this.underlying = message;
     }
@@ -63,6 +63,10 @@ public class EMFSingleMessage extends EMFMessage {
         return new EMFSingleMessage(
             ComponentMessage.componentMessage(Component.empty())
         );
+    }
+
+    public static EMFSingleMessage ofUnderlying(@NotNull ComponentSingleMessage underlying) {
+        return new EMFSingleMessage(underlying);
     }
 
     public static EMFSingleMessage of(@NotNull Component component) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
@@ -1,12 +1,9 @@
 package com.oheers.fish.messages.abstracted;
 
-import com.oheers.fish.FishUtils;
 import com.oheers.fish.messages.EMFListMessage;
 import com.oheers.fish.messages.EMFSingleMessage;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextColor;
-import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -15,7 +12,9 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import uk.firedev.messagelib.message.ComponentListMessage;
 import uk.firedev.messagelib.message.ComponentMessage;
+import uk.firedev.messagelib.message.ComponentSingleMessage;
 import uk.firedev.messagelib.message.MessageType;
 
 import java.util.Collection;
@@ -40,6 +39,16 @@ public abstract class EMFMessage {
     protected boolean perPlayer = true;
     protected boolean canSilent = false;
     protected OfflinePlayer relevantPlayer = null;
+
+    public static EMFMessage fromUnderlying(@NotNull ComponentMessage message) {
+        if (message instanceof ComponentListMessage listMessage) {
+            return EMFListMessage.ofUnderlying(listMessage);
+        } else if (message instanceof ComponentSingleMessage singleMessage) {
+            return EMFSingleMessage.ofUnderlying(singleMessage);
+        } else {
+            throw new IllegalArgumentException("Unknown ComponentMessage type");
+        }
+    }
 
     protected EMFMessage() {}
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
@@ -216,6 +216,13 @@ public abstract class EMFMessage {
      * @param replacement The replacement for the variable.
      */
     public void setVariable(@NotNull final String variable, @NotNull final Object replacement) {
+        // Explicitly handle EMFMessage replacements to avoid ending up with the toString of the object.
+        if (replacement instanceof EMFMessage emfMessage) {
+            setUnderlying(
+                getUnderlying().replace(variable, emfMessage.getUnderlying())
+            );
+            return;
+        }
         setUnderlying(
             getUnderlying().replace(variable, replacement)
         );

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
@@ -12,8 +12,11 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import uk.firedev.messagelib.message.ComponentMessage;
+import uk.firedev.messagelib.message.MessageType;
 
 import java.util.Collection;
 import java.util.List;
@@ -42,27 +45,34 @@ public abstract class EMFMessage {
 
     public abstract EMFMessage createCopy();
 
-    public static Component formatString(@NotNull String message) {
-        if (FishUtils.isLegacyString(message)) {
-            return LEGACY_SERIALIZER_INPUT.deserialize(message);
-        } else {
-            return MINIMESSAGE.deserialize(
-                message.replace('§', '&')
-            );
+    public abstract @NotNull ComponentMessage getUnderlying();
+
+    public abstract void setUnderlying(@NotNull ComponentMessage message);
+
+    public final void send(@NotNull Audience target) {
+        if (target instanceof Player player) {
+            getUnderlying().replace("{player}", player.getName())
+                .parsePlaceholderAPI(player)
+                .send(player);
+            return;
         }
+        getUnderlying().send(target);
     }
-
-    public static @NotNull Component removeDefaultItalics(@NotNull Component component) {
-        return FishUtils.decorateIfAbsent(component, TextDecoration.ITALIC, TextDecoration.State.FALSE);
-    }
-
-    public abstract void send(@NotNull Audience target);
 
     public void send(@NotNull Collection<? extends Audience> targets) {
         targets.forEach(this::send);
     }
 
-    public abstract void sendActionBar(@NotNull Audience target);
+    public final void sendActionBar(@NotNull Audience target) {
+        if (target instanceof Player player) {
+            getUnderlying().messageType(MessageType.ACTION_BAR)
+                .replace("{player}", player.getName())
+                .parsePlaceholderAPI(player)
+                .send(player);
+            return;
+        }
+        getUnderlying().messageType(MessageType.ACTION_BAR).send(target);
+    }
 
     public void sendActionBar(@NotNull Collection<? extends Audience> targets) {
         targets.forEach(this::sendActionBar);
@@ -136,47 +146,67 @@ public abstract class EMFMessage {
 
     // Append
 
-    public abstract void appendString(@NotNull String string);
+    public final void appendString(@NotNull String string) {
+        setUnderlying(
+            getUnderlying().append(string)
+        );
+    }
 
-    public void appendStringList(@NotNull List<String> strings) {
+    public final void appendStringList(@NotNull List<String> strings) {
         strings.forEach(this::appendString);
     }
 
-    public abstract void appendMessage(@NotNull EMFMessage message);
+    public final void appendMessage(@NotNull EMFMessage message) {
+        setUnderlying(
+            getUnderlying().append(message.getUnderlying())
+        );
+    }
 
-    public void appendMessageList(@NotNull List<EMFMessage> messages) {
+    public final void appendMessageList(@NotNull List<EMFMessage> messages) {
         messages.forEach(this::appendMessage);
     }
 
-    public abstract void appendComponent(@NotNull Component component);
+    public final void appendComponent(@NotNull Component component) {
+        setUnderlying(
+            getUnderlying().append(component)
+        );
+    }
 
-    public void appendComponentList(@NotNull List<Component> components) {
+    public final void appendComponentList(@NotNull List<Component> components) {
         components.forEach(this::appendComponent);
     }
 
     // Prepend
 
-    public abstract void prependString(@NotNull String string);
+    public final void prependString(@NotNull String string) {
+        setUnderlying(
+            getUnderlying().prepend(string)
+        );
+    }
 
-    public void prependStringList(@NotNull List<String> strings) {
+    public final void prependStringList(@NotNull List<String> strings) {
         strings.forEach(this::prependString);
     }
 
-    public abstract void prependMessage(@NotNull EMFMessage message);
+    public final void prependMessage(@NotNull EMFMessage message) {
+        setUnderlying(
+            getUnderlying().prepend(message.getUnderlying())
+        );
+    }
 
-    public void prependMessageList(@NotNull List<EMFMessage> messages) {
+    public final void prependMessageList(@NotNull List<EMFMessage> messages) {
         messages.forEach(this::prependMessage);
     }
 
-    public abstract void prependComponent(@NotNull Component component);
-
-    public void prependComponentList(@NotNull List<Component> components) {
-        components.forEach(this::prependComponent);
+    public final void prependComponent(@NotNull Component component) {
+        setUnderlying(
+            getUnderlying().prepend(component)
+        );
     }
 
-    public abstract void decorateIfAbsent(@NotNull TextDecoration decoration, @NotNull TextDecoration.State state);
-
-    public abstract void colorIfAbsent(@NotNull TextColor color);
+    public final void prependComponentList(@NotNull List<Component> components) {
+        components.forEach(this::prependComponent);
+    }
 
     // Variables
 
@@ -186,13 +216,9 @@ public abstract class EMFMessage {
      * @param replacement The replacement for the variable.
      */
     public void setVariable(@NotNull final String variable, @NotNull final Object replacement) {
-        if (replacement instanceof EMFMessage emfMessage) {
-            setEMFMessageVariable(variable, emfMessage);
-        } else if (replacement instanceof Component component) {
-            setComponentVariable(variable, component);
-        } else {
-            setComponentVariable(variable, formatString(String.valueOf(replacement)));
-        }
+        setUnderlying(
+            getUnderlying().replace(variable, replacement)
+        );
     }
 
     /**
@@ -203,12 +229,10 @@ public abstract class EMFMessage {
         if (variableMap == null || variableMap.isEmpty()) {
             return;
         }
-        variableMap.forEach(this::setVariable);
+        setUnderlying(
+            getUnderlying().replace(variableMap)
+        );
     }
-
-    protected abstract void setEMFMessageVariable(@NotNull final String variable, @NotNull final EMFMessage replacement);
-
-    protected abstract void setComponentVariable(@NotNull final String variable, @NotNull final Component replacement);
 
     /**
      * The player's name to replace the {player} variable. Also sets the relevantPlayer variable to this player.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/ConfigurationManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/ConfigurationManager.java
@@ -5,6 +5,11 @@ import com.oheers.fish.config.GuiConfig;
 import com.oheers.fish.config.GuiFillerConfig;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.MessageConfig;
+import com.oheers.fish.messages.EMFListMessage;
+import com.oheers.fish.messages.EMFSingleMessage;
+import com.oheers.fish.messages.abstracted.EMFMessage;
+import com.oheers.fish.recipe.EMFShapedRecipe;
+import uk.firedev.messagelib.ObjectProcessor;
 
 import java.util.logging.Level;
 
@@ -17,6 +22,8 @@ public class ConfigurationManager {
 
     public void loadConfigurations() {
         try {
+            prepareMessageLib();
+
             new MainConfig();
             new MessageConfig();
             new GuiConfig();
@@ -44,4 +51,16 @@ public class ConfigurationManager {
             plugin.getLogger().log(Level.SEVERE, "Failed to reload configurations", e);
         }
     }
+
+    private void prepareMessageLib() {
+        ObjectProcessor.registerProcessor(
+            EMFSingleMessage.class,
+            EMFMessage::getComponentListMessage
+        );
+        ObjectProcessor.registerProcessor(
+            EMFListMessage.class,
+            EMFListMessage::getComponentListMessage
+        );
+    }
+
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -78,6 +78,7 @@ dependencyResolutionManagement {
             plugin("plugin-yml", "de.eldoria.plugin-yml.bukkit").version("0.8.0")
 
             library("boostedyaml", "dev.dejvokep:boosted-yaml:1.3.7")
+            library("messagelib", "uk.firedev:MessageLib:1.0-SNAPSHOT")
 
             plugin("grgit", "org.ajoberstar.grgit").version("5.3.2")
 


### PR DESCRIPTION
## Description
Updates EMF's message system to be backed by my [MessageLib](https://github.com/FireML-Dev/MessageLib) library

---

### What has changed?
- Added MessageLib to handle messages.
- All EMFMessage methods now point to an underlying ComponentMessage.
- Massively cleaned up ConfigMessage using the library's methods.
- Fixes placeholders not parsing correctly in some places.
- Adds optional configs for the type of message. Example below:
```
  reload:
    type: subtitle
    message: "<white>Successfully reloaded the plugin."
```

---

### Related Issues
Closes #686

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.