### PR TITLE
Allow linked player in placeholders

### DIFF
--- a/docs/docs/configuration/Placeholders.md
+++ b/docs/docs/configuration/Placeholders.md
@@ -17,7 +17,9 @@ Below is a list of the plugin's placeholders and what they do:
 
 ### Economy:
 - `%emf_total_money_earned_{uuid}%` - The total amount of money earned by the player with the given UUID.
+- `%emf_total_money_earned_player%` - The total amount of money earned by the linked player.
 - `%emf_total_fish_sold_{uuid}%` - The total amount of fish sold by the player with the given UUID.
+- `%emf_total_fish_sold_player%` - The total amount of fish sold by the linked player.
 
 ### Player:
 - `%emf_custom_fishing_boolean%` - Whether custom fishing is enabled for the linked player or not. true/false.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/placeholders/PlaceholderReceiver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/placeholders/PlaceholderReceiver.java
@@ -235,8 +235,16 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
     }
 
     private @Nullable String handleTotalMoneyEarned(Player player, @NotNull String identifier) {
+        String substring = identifier.substring("total_money_earned_".length());
+        if (substring.equalsIgnoreCase("player")) {
+            if (player == null) {
+                return null;
+            }
+            UserReport userReport = plugin.getPluginDataManager().getUserReportDataManager().get(player.getUniqueId().toString());
+            return userReport != null ? String.format("%.2f", userReport.getMoneyEarned()) : null;
+        }
         try {
-            UUID uuid = UUID.fromString(identifier.substring("total_money_earned_".length()));
+            UUID uuid = UUID.fromString(substring);
             UserReport userReport = plugin.getPluginDataManager().getUserReportDataManager().get(uuid.toString());
             return userReport != null ? String.format("%.2f", userReport.getMoneyEarned()) : null;
         } catch (IllegalArgumentException e) {
@@ -245,8 +253,16 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
     }
 
     private @Nullable String handleTotalFishSold(Player player, @NotNull String identifier) {
+        String substring = identifier.substring("total_fish_sold_".length());
+        if (substring.equalsIgnoreCase("player")) {
+            if (player == null) {
+                return null;
+            }
+            UserReport userReport = plugin.getPluginDataManager().getUserReportDataManager().get(player.getUniqueId().toString());
+            return userReport != null ? String.valueOf(userReport.getFishSold()) : null;
+        }
         try {
-            UUID uuid = UUID.fromString(identifier.substring("total_fish_sold_".length()));
+            UUID uuid = UUID.fromString(substring);
             UserReport userReport = plugin.getPluginDataManager().getUserReportDataManager().get(uuid.toString());
             return userReport != null ? String.valueOf(userReport.getFishSold()) : null;
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
### What has changed?
- The placeholders that accept UUIDs now also accept `player` to use the linked player.
  - `%emf_total_money_earned_player%`
  - `%emf_total_fish_sold_player%`
- Updated the placeholder docs to include these new options.

---

### Related Issues
Requested on Discord.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.