### PR TITLE
Last second fixes

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -215,7 +215,6 @@ public class EvenMoreFish extends EMFPlugin {
 
     @Override
     public void reload(@Nullable CommandSender sender) {
-
         terminateGuis();
 
         this.configurationManager.reloadConfigurations();
@@ -224,7 +223,6 @@ public class EvenMoreFish extends EMFPlugin {
         BaitManager.getInstance().reload();
         RodManager.getInstance().reload();
 
-        HandlerList.unregisterAll(FishEatEvent.getInstance());
         HandlerList.unregisterAll(FishInteractEvent.getInstance());
         HandlerList.unregisterAll(McMMOTreasureEvent.getInstance());
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/economy/VaultEconomyType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/economy/VaultEconomyType.java
@@ -98,13 +98,14 @@ public class VaultEconomyType implements EconomyType {
             return null;
         }
         double worth = prepareValue(totalWorth, applyMultiplier);
+        Component worthFormatted = FishUtils.formatDouble(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getPlainTextMessage(), worth);
         String display = MainConfig.getInstance().getEconomyDisplay(this);
         if (display != null) {
             EMFSingleMessage message = EMFSingleMessage.fromString(display);
-            message.setVariable("{amount}", String.valueOf(worth));
+            message.setVariable("{amount}", worthFormatted);
             return message.getComponentMessage();
         }
-        return FishUtils.formatDouble(ConfigMessage.SELL_PRICE_FORMAT.getMessage().getPlainTextMessage(), worth);
+        return worthFormatted;
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/events/FishEatEvent.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/events/FishEatEvent.java
@@ -6,20 +6,17 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 
-public class FishEatEvent implements Listener {
+public class FishEatEvent {
 
     private static final FishEatEvent eatEvent = new FishEatEvent();
 
-    private FishEatEvent() {
-
-    }
+    private FishEatEvent() {}
 
     public static FishEatEvent getInstance() {
         return eatEvent;
     }
 
-    @EventHandler
-    public void onEatItem(final PlayerItemConsumeEvent event) {
+    public boolean checkEatEvent(PlayerItemConsumeEvent event) {
         // Checks if the eaten item is a fish
         if (FishUtils.isFish(event.getItem())) {
             // Creates a replica of the fish we can use
@@ -29,8 +26,11 @@ public class FishEatEvent implements Listener {
                 if (fish.hasEatRewards()) {
                     // Runs through each eat-event
                     fish.getActionRewards().forEach(r -> r.rewardPlayer(event.getPlayer(), null));
+                    return true;
                 }
             }
+            return false;
         }
+        return false;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -356,8 +356,6 @@ public class Fish {
         List<String> configRewards = section.getStringList("eat-event");
         // Checks if the player has actually set reward for an eat event
         if (!configRewards.isEmpty()) {
-            // Informs the main class to load up an PlayerItemConsumeEvent listener
-            EvenMoreFish.getInstance().getEventManager().setCheckingEatEvent(true);
             this.eventType = "eat";
             actionRewards = new ArrayList<>();
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
@@ -54,5 +54,5 @@ public class EventManager {
     public void setCheckingIntEvent(boolean checkingIntEvent) {
         this.checkingIntEvent = checkingIntEvent;
     }
-    
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
@@ -16,10 +16,10 @@ import com.oheers.fish.utils.ItemProtectionListener;
 import org.bukkit.plugin.PluginManager;
 
 public class EventManager {
+
     private final EvenMoreFish plugin;
     private final PluginManager pm;
 
-    private boolean checkingEatEvent;
     private boolean checkingIntEvent;
 
     public EventManager(EvenMoreFish plugin) {
@@ -45,20 +45,14 @@ public class EventManager {
     }
 
     public void registerOptionalListeners() {
-        if (checkingEatEvent) {
-            pm.registerEvents(FishEatEvent.getInstance(), plugin);
-        }
         if (checkingIntEvent) {
             pm.registerEvents(FishInteractEvent.getInstance(), plugin);
         }
         plugin.getDependencyManager().checkOptionalDependencies();
     }
 
-    public void setCheckingEatEvent(boolean checkingEatEvent) {
-        this.checkingEatEvent = checkingEatEvent;
-    }
-
     public void setCheckingIntEvent(boolean checkingIntEvent) {
         this.checkingIntEvent = checkingIntEvent;
     }
+    
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemProtectionListener.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemProtectionListener.java
@@ -2,6 +2,7 @@ package com.oheers.fish.utils;
 
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.config.MainConfig;
+import com.oheers.fish.events.FishEatEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockCookEvent;
@@ -32,7 +33,8 @@ public class ItemProtectionListener implements Listener {
     // Protect against consuming an EMF item.
     @EventHandler
     public void onConsume(PlayerItemConsumeEvent event) {
-        if (!MainConfig.getInstance().blockConsume()) {
+        // If the fish has eat-event, ignore item protection.
+        if (FishEatEvent.getInstance().checkEatEvent(event) || !MainConfig.getInstance().blockConsume()) {
             return;
         }
         ItemStack item = event.getItem();


### PR DESCRIPTION
### What has changed?
- Fixed a conflict between eat-event and item protections.
  - If eat-event is present on a fish, item protection is ignored.
- Ensured player-visible economy values are always rounded.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.