### PR TITLE
Make the empty ConfigBase use the EMF plugin

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.config;
 
+import com.oheers.fish.EvenMoreFish;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.dvs.versioning.BasicVersioning;
 import dev.dejvokep.boostedyaml.settings.Settings;
@@ -9,6 +10,7 @@ import dev.dejvokep.boostedyaml.settings.loader.LoaderSettings;
 import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,7 +58,7 @@ public class ConfigBase {
         this.preventIO = true;
         this.fileName = null;
         this.resourceName = null;
-        this.plugin = null;
+        this.plugin = EvenMoreFish.getInstance();
         this.configUpdater = false;
 
         try {
@@ -100,13 +102,13 @@ public class ConfigBase {
         return this.config;
     }
 
-    public final File getFile() { return this.file; }
+    public final @Nullable File getFile() { return this.file; }
 
-    public final Plugin getPlugin() { return this.plugin; }
+    public final @NotNull Plugin getPlugin() { return this.plugin; }
 
-    public final String getFileName() { return this.fileName; }
+    public final @Nullable String getFileName() { return this.fileName; }
 
-    public final String getResourceName() { return this.resourceName; }
+    public final @Nullable String getResourceName() { return this.resourceName; }
 
     public Settings[] getSettings() {
         List<Settings> settingsList = new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
### What has changed?
- An empty ConfigBase now uses the EMF plugin for its instance.
- ConfigBase getter methods are now correctly annotated.

---

### Related Issues
- Fixes a NPE when running the `/emfa competition test` command.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.