### PR TITLE
AFK Fishing

### DIFF
--- a/docs/docs/features/exploit-prevention.md
+++ b/docs/docs/features/exploit-prevention.md
@@ -1,0 +1,21 @@
+---
+title: Exploit Prevention
+---
+
+## Exploit Prevention
+EvenMoreFish provides some exploit protections that can be configured in config.yml.
+
+### AFK Fishing
+AFK Fishing is the act of standing in one place and repeatedly catching fish. This can be prevented using the `exploits.afk-fishing` configs.
+
+This system is mutually exclusive with mcMMO's Overfishing. If Overfishing is enabled, EMF's AFK Fishing system will not function.
+
+### Items
+While not technically exploits, EvenMoreFish protects items from various actions by default.
+
+These can be toggled with the `item-protection` configs.
+
+These actions include but are not limited to:
+- Using them in recipes
+- Using them as furnace fuel
+- Cooking them in a furnace.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/Checks.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/Checks.java
@@ -5,7 +5,9 @@ import br.net.fabiozumbi12.RedProtect.Bukkit.Region;
 import com.gmail.nossr50.config.experience.ExperienceConfig;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.util.player.UserManager;
+import com.oheers.fish.api.Logging;
 import com.oheers.fish.config.MainConfig;
+import com.oheers.fish.fishing.exploits.AFKFishingTracker;
 import com.oheers.fish.fishing.rods.CustomRod;
 import com.oheers.fish.fishing.rods.RodManager;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -20,6 +22,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,6 +33,7 @@ import java.util.stream.Stream;
 /**
  * A utility class for common checks
  */
+@ApiStatus.Internal
 public class Checks {
 
     /**
@@ -104,6 +108,13 @@ public class Checks {
             Region region = RedProtect.get().getAPI().getRegion(location);
             return region != null && allowedRegions.contains(region.getName());
         }
+    }
+
+    public static boolean isAFKFishing(@NotNull Player player) {
+        if (!MainConfig.getInstance().isAFKProtectionEnabled()) {
+            return false;
+        }
+        return AFKFishingTracker.get(player.getUniqueId()).isAFKFishing();
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -504,7 +504,8 @@ public class MainConfig extends ConfigBase {
     }
 
     public int getAFKMaxFishCaught() {
-        return getConfig().getInt("exploits.afk-fishing.max-caught", 10);
+        // Internally add 1 because otherwise it'll stop on the number instead of after.
+        return getConfig().getInt("exploits.afk-fishing.max-caught", 10) + 1;
     }
 
     public int getAFKCheckRange() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -1,13 +1,16 @@
 package com.oheers.fish.config;
 
+import com.gmail.nossr50.config.experience.ExperienceConfig;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.FishUtils;
+import com.oheers.fish.api.Logging;
 import com.oheers.fish.api.config.ConfigBase;
 import com.oheers.fish.api.config.serializer.BossBarOverlaySerializer;
 import com.oheers.fish.api.economy.EconomyType;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings;
 import net.kyori.adventure.bossbar.BossBar;
+import org.bukkit.Bukkit;
 import org.bukkit.block.Biome;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -487,6 +490,25 @@ public class MainConfig extends ConfigBase {
 
     public boolean getBaitShowUnusedSlots() {
         return getConfig().getBoolean("bait.show-unused-slots", true);
+    }
+
+    // Exploit Configs
+
+    public boolean isAFKProtectionEnabled() {
+        boolean enabled = getConfig().getBoolean("exploits.afk-fishing.enabled", false);
+        if (enabled && Bukkit.getPluginManager().isPluginEnabled("mcMMO") && ExperienceConfig.getInstance().isFishingExploitingPrevented()) {
+            Logging.warn("mcMMO Overfishing is enabled. EMF's Anti-AFK features will not function.");
+            return false;
+        }
+        return enabled;
+    }
+
+    public int getAFKMaxFishCaught() {
+        return getConfig().getInt("exploits.afk-fishing.max-caught", 10);
+    }
+
+    public int getAFKCheckRange() {
+        return getConfig().getInt("exploits.afk-fishing.range", 3);
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/AFKFishingTracker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/AFKFishingTracker.java
@@ -1,0 +1,62 @@
+package com.oheers.fish.fishing.exploits;
+
+import com.oheers.fish.config.MainConfig;
+import com.oheers.fish.messages.EMFSingleMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.util.BoundingBox;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Tracks if the player is AFK fishing.
+ */
+public class AFKFishingTracker {
+
+    private static final Map<UUID, AFKFishingTracker> STORED = new HashMap<>();
+
+    private final UUID player;
+
+    private int caught = 0;
+    private @Nullable BoundingBox box;
+
+    public static @NotNull AFKFishingTracker get(@NotNull UUID player) {
+        return STORED.computeIfAbsent(player, AFKFishingTracker::new);
+    }
+
+    public static void invalidate(@NotNull UUID player) {
+        STORED.remove(player);
+    }
+
+    private AFKFishingTracker(@NotNull UUID player) {
+        System.out.println("Created new fishing tracker for " + player);
+        this.player = player;
+    }
+
+    public void trackAFKFishing(@NotNull Location location) {
+        Vector vector = location.toVector();
+        int range = MainConfig.getInstance().getAFKCheckRange();
+        BoundingBox currentBox = BoundingBox.of(vector, range, range, range);
+
+        if (this.box == null || !this.box.overlaps(currentBox)) {
+            this.box = currentBox;
+            caught = 1;
+            return;
+        }
+
+        caught++;
+        if (caught + 1 == MainConfig.getInstance().getAFKMaxFishCaught()) {
+            EMFSingleMessage.fromString("AFK Fishing detected").getUnderlying().send(Bukkit.getPlayer(player));
+        }
+    }
+
+    public boolean isAFKFishing() {
+        return this.caught >= MainConfig.getInstance().getAFKMaxFishCaught();
+    }
+
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/AFKFishingTracker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/AFKFishingTracker.java
@@ -1,9 +1,12 @@
 package com.oheers.fish.fishing.exploits;
 
 import com.oheers.fish.config.MainConfig;
+import com.oheers.fish.messages.ConfigMessage;
 import com.oheers.fish.messages.EMFSingleMessage;
+import com.oheers.fish.messages.abstracted.EMFMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -51,7 +54,13 @@ public class AFKFishingTracker {
 
         caught++;
         if (caught + 1 == MainConfig.getInstance().getAFKMaxFishCaught()) {
-            EMFSingleMessage.fromString("AFK Fishing detected").getUnderlying().send(Bukkit.getPlayer(player));
+            Player online = Bukkit.getPlayer(player);
+            if (online == null) {
+                return;
+            }
+            EMFMessage message = ConfigMessage.EXPLOITS_AFK_FISHING_DETECTED.getMessage();
+            message.setVariable("{range}", MainConfig.getInstance().getAFKCheckRange());
+            message.send(online);
         }
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/AFKFishingTracker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/AFKFishingTracker.java
@@ -1,8 +1,8 @@
 package com.oheers.fish.fishing.exploits;
 
+import com.oheers.fish.api.Logging;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.messages.ConfigMessage;
-import com.oheers.fish.messages.EMFSingleMessage;
 import com.oheers.fish.messages.abstracted.EMFMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -37,7 +37,7 @@ public class AFKFishingTracker {
     }
 
     private AFKFishingTracker(@NotNull UUID player) {
-        System.out.println("Created new fishing tracker for " + player);
+        Logging.debug("Created new fishing tracker for " + player);
         this.player = player;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/ExploitListener.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/ExploitListener.java
@@ -2,6 +2,8 @@ package com.oheers.fish.fishing.exploits;
 
 import com.oheers.fish.api.Logging;
 import com.oheers.fish.config.MainConfig;
+import com.oheers.fish.messages.ConfigMessage;
+import com.oheers.fish.messages.abstracted.EMFMessage;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -34,7 +36,11 @@ public class ExploitListener implements Listener {
         tracker.trackAFKFishing(event.getHook().getLocation());
         if (tracker.isAFKFishing()) {
             Logging.debug(event.getPlayer().getName() + " is AFK Fishing.");
-            ComponentMessage.componentMessage("You are AFK Fishing. Move your hook at least 3 blocks away.").send(event.getPlayer());
+
+            EMFMessage message = ConfigMessage.EXPLOITS_AFK_FISHING_BLOCKED.getMessage();
+            message.setVariable("{range}", MainConfig.getInstance().getAFKCheckRange());
+            message.send(event.getPlayer());
+
             event.setExpToDrop(0);
             event.getHook().remove();
             event.setCancelled(true);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/ExploitListener.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/exploits/ExploitListener.java
@@ -1,0 +1,51 @@
+package com.oheers.fish.fishing.exploits;
+
+import com.oheers.fish.api.Logging;
+import com.oheers.fish.config.MainConfig;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.evenmorefish.dimensionfishing.util.Keys;
+import uk.firedev.messagelib.message.ComponentMessage;
+
+public class ExploitListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onFish(PlayerFishEvent event) {
+        if (!MainConfig.getInstance().isAFKProtectionEnabled()) {
+            return;
+        }
+        PlayerFishEvent.State state = event.getState();
+        if (state != PlayerFishEvent.State.CAUGHT_FISH && state != PlayerFishEvent.State.CAUGHT_ENTITY) {
+            return;
+        }
+        // Handle DimensionFishing.
+        if (state == PlayerFishEvent.State.CAUGHT_ENTITY) {
+            Entity caught = event.getCaught();
+            if (caught != null && !caught.getPersistentDataContainer().has(Keys.STAND_KEY)) {
+                return;
+            }
+        }
+        Logging.debug("Checking for AFK Fishing.");
+        AFKFishingTracker tracker = AFKFishingTracker.get(event.getPlayer().getUniqueId());
+        tracker.trackAFKFishing(event.getHook().getLocation());
+        if (tracker.isAFKFishing()) {
+            Logging.debug(event.getPlayer().getName() + " is AFK Fishing.");
+            ComponentMessage.componentMessage("You are AFK Fishing. Move your hook at least 3 blocks away.").send(event.getPlayer());
+            event.setExpToDrop(0);
+            event.getHook().remove();
+            event.setCancelled(true);
+        } else {
+            Logging.debug(event.getPlayer().getName() + " is not AFK Fishing.");
+        }
+    }
+
+    @EventHandler
+    public void onDisconnect(PlayerQuitEvent event) {
+        AFKFishingTracker.invalidate(event.getPlayer().getUniqueId());
+    }
+
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/processors/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/processors/FishingProcessor.java
@@ -8,13 +8,18 @@ import com.oheers.fish.api.fishing.CatchType;
 import com.oheers.fish.competition.Competition;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.fishing.Processor;
+import com.oheers.fish.fishing.exploits.AFKFishingTracker;
 import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.messages.ConfigMessage;
+import com.oheers.fish.messages.EMFSingleMessage;
 import com.oheers.fish.permissions.UserPerms;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -40,22 +45,22 @@ public class FishingProcessor extends Processor<PlayerFishEvent> implements List
         ItemStack rod = getRod(event);
 
         if (rod == null) {
-            plugin.debug("Fishing blocked: could not find rod.");
+            plugin.debug("Custom fishing blocked: could not find rod.");
             return;
         }
 
         if (!isCustomFishAllowed(event.getPlayer())) {
-            plugin.debug("Fishing blocked: custom fish not allowed for player %s.".formatted(event.getPlayer().getName()));
+            plugin.debug("Custom fishing blocked: custom fish not allowed for player %s.".formatted(event.getPlayer().getName()));
             return;
         }
 
         if (!Checks.canUseRod(rod)) {
-            plugin.debug("Fishing blocked: rod unusable (%s).".formatted(rod));
+            plugin.debug("Custom fishing blocked: rod unusable (%s).".formatted(rod));
             return;
         }
 
         if (MainConfig.getInstance().requireFishingPermission() && !event.getPlayer().hasPermission(UserPerms.USE_ROD)) {
-            plugin.debug("Fishing blocked: permission required and player lacks it.");
+            plugin.debug("Custom fishing blocked: permission required and player lacks it.");
             if (event.getState() == PlayerFishEvent.State.FISHING) {
                 //send msg only when throw the lure
                 ConfigMessage.NO_PERMISSION_FISHING.getMessage().send(event.getPlayer());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/ConfigMessage.java
@@ -205,7 +205,10 @@ public enum ConfigMessage {
     BAIT_BOOSTS_RARITY(PrefixType.NONE, "bait.boosts-rarity"),
     BAIT_BOOSTS_RARITIES(PrefixType.NONE, "bait.boosts-rarities"),
     BAIT_BOOSTS_FISH(PrefixType.NONE, "bait.boosts-fish"),
-    BAIT_UNUSED_SLOT(PrefixType.NONE, "bait.unused-slot");
+    BAIT_UNUSED_SLOT(PrefixType.NONE, "bait.unused-slot"),
+
+    EXPLOITS_AFK_FISHING_DETECTED(PrefixType.ERROR, "exploits.afk-fishing.detected"),
+    EXPLOITS_AFK_FISHING_BLOCKED(PrefixType.ERROR, "exploits.afk-fishing.blocked");
 
     private final String id;
     private final PrefixType prefixType;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
@@ -8,6 +8,7 @@ import com.oheers.fish.database.DatabaseUtil;
 import com.oheers.fish.events.FishInteractEvent;
 import com.oheers.fish.events.JoinChecker;
 import com.oheers.fish.fishing.EMFFishListener;
+import com.oheers.fish.fishing.exploits.ExploitListener;
 import com.oheers.fish.fishing.processors.FishingProcessor;
 import com.oheers.fish.fishing.processors.HuntingProcessor;
 import com.oheers.fish.recipe.RecipeListener;
@@ -42,6 +43,7 @@ public class EventManager {
         pm.registerEvents(new ItemProtectionListener(), plugin);
         pm.registerEvents(new FishInteractEvent(), plugin);
         pm.registerEvents(new RecipeListener(), plugin);
+        pm.registerEvents(new ExploitListener(), plugin);
     }
 
     public void registerOptionalListeners() {

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -38,6 +38,17 @@ fishing:
   # Allows spawner fish to be ignored for hunting
   hunt-ignore-spawner-fish: true
 
+# Exploit Configs
+exploits:
+  # AFK Fishing - If mcMMO's Overfishing is enabled, this will have no functionality.
+  afk-fishing:
+    # Should AFK fishing be protected against? (Default: false)
+    enabled: false
+    # How many fish can be caught before needing to move the hook?
+    max-caught: 10
+    # How far should the player need to move their hook?
+    range: 3
+
 # Backs up active competitions to a file.
 # Useful for crashes and such.
 competition-backup:
@@ -291,5 +302,5 @@ dimension-fishing:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-version: 9
+version: 10
 

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -329,6 +329,13 @@ bait:
   # This is added to the lore in place of a bait if show-unused-slots is enabled in the general section.
   unused-slot: <gray>► ? <i>Available Slot
 
+exploits:
+  afk-fishing:
+    # When AFK Fishing is detected. This is sent on the final fish before the limit.
+    detected: "<white>There are no more fish in this area. Try moving your hook at least {range} blocks away."
+    # When AFK Fishing is blocked.
+    blocked: "<white>There are no more fish in this area. Try moving your hook at least {range} blocks away."
+
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-version: 14
+version: 15

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ bstats = "org.bstats:bstats-bukkit:3.2.1"
 kotlin-gradle-plugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0"
 
 # DimensionFishing
-dimensionfishing = "org.evenmorefish:DimensionFishing:1.0"
+dimensionfishing = "org.evenmorefish:DimensionFishing:1.0.1-SNAPSHOT"
 
 # World Management
 worldguard-core = { module = "com.sk89q.worldguard:worldguard-core", version.ref = "worldguard" }


### PR DESCRIPTION
## Description
Adds configs to prevent AFK Fishing.

The AFK Fishing system is mutually exclusive with mcMMO's Overfishing. If Overfishing is enabled, this system will not function.

This works with vanilla fishing, and the types provided by DimensionFishing.

---

### What has changed?
- Updated DimensionFishing to 1.0.1-SNAPSHOT
- Added `ExploitListener` for tracking exploits.
- Added `AFKFishingTracker.`
  - This tracks the AFK fishing for a player. Each instance is stored in a map and removed on disconnect.
- Added `Checks#isAFKFishing`.
  - This is unused for now, as the exploit listener cancels the fish event.

---

### Related Issues
Closes #368 

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.