### PR TITLE
Async database I/O: move DB writes off the main thread

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
@@ -254,6 +254,16 @@ public class Database implements DatabaseAPI {
         useHandle(handle -> bindUserFishStatsUpdate(handle, userFishStatsUpsertSql(), userFishStats).execute());
     }
 
+    /**
+     * Loads every fish stats row belonging to a user in one query, for
+     * cache preloading on join.
+     *
+     * @return all rows for the user (possibly empty), or null if the query failed
+     */
+    public List<UserFishStats> loadAllUserFishStats(int userId) {
+        return withHandle(handle -> handle.createQuery("select user_id, fish_name, fish_rarity, first_catch_time, shortest_length, longest_length, quantity from " + userFishStatsTable + " where user_id = :user_id").bind("user_id", userId).mapTo(UserFishStats.class).list(), null);
+    }
+
     @Override
     public Set<FishLog> getFishLogEntries(int userId, String fishName, String fishRarity) {
         return withHandle(handle -> new LinkedHashSet<>(handle.createQuery("select id, user_id, fish_name, fish_rarity, fish_length, catch_time, competition_id from " + fishLogTable + " where user_id = :user_id and fish_name = :fish_name and fish_rarity = :fish_rarity").bind("user_id", userId).bind("fish_name", fishName).bind("fish_rarity", fishRarity).mapTo(FishLog.class).list()), Set.of());
@@ -279,6 +289,17 @@ public class Database implements DatabaseAPI {
 
     public void upsertFishStats(@NotNull FishStats fishStats) {
         useTransaction(handle -> bindFishStatsUpdate(handle, fishStats).execute());
+    }
+
+    /**
+     * Loads every global fish stats row in one query, for cache preloading
+     * at startup. The table holds one row per fish/rarity pair, so this is
+     * bounded by the configured fish count.
+     *
+     * @return all rows (possibly empty), or null if the query failed
+     */
+    public List<FishStats> loadAllFishStats() {
+        return withHandle(handle -> handle.createQuery("select fish_name, fish_rarity, first_catch_time, discoverer, shortest_length, shortest_fisher, largest_fish, largest_fisher, total_caught from " + fishTable).mapTo(FishStats.class).list(), null);
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/connection/ConnectionFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/connection/ConnectionFactory.java
@@ -60,7 +60,13 @@ public abstract class ConnectionFactory {
         configureDatabase(config, getDatabaseAddress(), getDatabasePort(), MainConfig.getInstance().getDatabase(), MainConfig.getInstance().getUsername(), MainConfig.getInstance().getPassword());
         config.setInitializationFailTimeout(-1);
         config.setValidationTimeout(5000);
-        config.addDataSourceProperty("validateBorrowedConnections", true);
+        // Cap how long a borrower can wait for a connection; the Hikari
+        // default of 30s can stall a caller for the full window when the
+        // database link degrades.
+        config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(5));
+        // Ping idle connections so links over VPN/NAT stay warm instead of
+        // being silently dropped and failing at borrow time.
+        config.setKeepaliveTime(TimeUnit.MINUTES.toMillis(1));
         config.setLeakDetectionThreshold(30000);
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/DatabaseWriteQueue.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/DatabaseWriteQueue.java
@@ -1,0 +1,80 @@
+package com.oheers.fish.database.data;
+
+import com.oheers.fish.EvenMoreFish;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Serialises all database writes onto a single background thread so blocking
+ * JDBC calls never run on the server thread. Tasks execute strictly in
+ * submission order, which preserves the relative ordering of dependent writes
+ * (e.g. a user row is created before that user's fish logs are inserted).
+ */
+public class DatabaseWriteQueue implements Executor {
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable);
+        thread.setName("emf-db-writer-" + THREAD_COUNTER.getAndIncrement());
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    @Override
+    public void execute(@NotNull Runnable task) {
+        try {
+            executor.execute(() -> runLogged(task));
+        } catch (RejectedExecutionException e) {
+            // Queue already shut down (plugin disable in progress). Run inline
+            // so the write is not lost; blocking the caller is fine here.
+            runLogged(task);
+        }
+    }
+
+    /**
+     * Stops accepting new tasks and blocks until every queued write has
+     * completed, or the timeout elapses. Call on plugin disable, before the
+     * connection pool is closed.
+     *
+     * @return true if the queue drained fully, false if writes were dropped
+     */
+    public boolean shutdown(long timeout, @NotNull TimeUnit unit) {
+        executor.shutdown();
+        try {
+            if (executor.awaitTermination(timeout, unit)) {
+                return true;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        List<Runnable> dropped = executor.shutdownNow();
+        logger().warning("Database write queue did not drain in time; " + dropped.size() + " pending write(s) were dropped.");
+        return false;
+    }
+
+    private void runLogged(Runnable task) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            logger().log(Level.SEVERE, "Async database write failed.", e);
+        }
+    }
+
+    private Logger logger() {
+        try {
+            return EvenMoreFish.getInstance().getLogger();
+        } catch (RuntimeException ignored) {
+            // Unit tests and early bootstrap paths may not have an initialized plugin singleton.
+            return Logger.getLogger("EvenMoreFish");
+        }
+    }
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/manager/UserManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/manager/UserManager.java
@@ -9,30 +9,40 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.function.ObjIntConsumer;
 
 public class UserManager implements Listener {
     private final Database database;
+    private final Executor writeExecutor;
+    private final ObjIntConsumer<UUID> joinPreloadHook;
     private final Map<UUID, Integer> userCache;
 
-    public UserManager(Database database) {
+    public UserManager(Database database, Executor writeExecutor, @Nullable ObjIntConsumer<UUID> joinPreloadHook) {
         this.database = database;
+        this.writeExecutor = writeExecutor;
+        this.joinPreloadHook = joinPreloadHook;
         this.userCache = new ConcurrentHashMap<>();
     }
 
     @EventHandler
     public void onJoin(final @NotNull PlayerJoinEvent event) {
         final UUID uuid = event.getPlayer().getUniqueId();
-        int id = database.getUserId(uuid);
-        if (id == 0) {
-            id = EvenMoreFish.getInstance().getPluginDataManager().getDatabase().upsertUserReport(new EmptyUserReport(event.getPlayer().getUniqueId()));
-        }
-
-        userCache.putIfAbsent(uuid, id);
-        EvenMoreFish.getInstance().debug("User ID: %d UUID: %s".formatted(id, uuid));
+        // Resolve (creating if missing) the user row off the server thread.
+        // The write executor is single-threaded and FIFO, so the row is
+        // guaranteed to exist before any subsequently queued writes that
+        // reference this user.
+        writeExecutor.execute(() -> {
+            int id = loadOrCreateUser(uuid);
+            if (id != 0 && joinPreloadHook != null) {
+                joinPreloadHook.accept(uuid, id);
+            }
+        });
     }
 
     @EventHandler
@@ -40,6 +50,12 @@ public class UserManager implements Listener {
         userCache.remove(event.getPlayer().getUniqueId());
     }
 
+    /**
+     * Resolves the user's database id, using the cache populated on join.
+     * On a cache miss (a fish caught before the join-time load completed,
+     * or after a plugin reload) this falls back to a blocking lookup on the
+     * calling thread.
+     */
     public int getUserId(final UUID uuid) {
         Integer id = userCache.get(uuid);
         if (id != null) {
@@ -50,6 +66,19 @@ public class UserManager implements Listener {
         if (id != 0) {
             userCache.put(uuid, id);
         }
+        return id;
+    }
+
+    private int loadOrCreateUser(final UUID uuid) {
+        int id = database.getUserId(uuid);
+        if (id == 0) {
+            id = database.upsertUserReport(new EmptyUserReport(uuid));
+        }
+
+        if (id != 0) {
+            userCache.putIfAbsent(uuid, id);
+        }
+        EvenMoreFish.getInstance().debug("User ID: %d UUID: %s".formatted(id, uuid));
         return id;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/BufferedSavingStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/BufferedSavingStrategy.java
@@ -2,31 +2,49 @@ package com.oheers.fish.database.data.strategy;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
+/**
+ * Buffers updates for periodic batch flushing. When an executor is supplied,
+ * both the write-through-on-create path and batch flushes are dispatched to
+ * it so callers (the server thread flushing on player quit, or the periodic
+ * flush scheduler) never block on database I/O.
+ */
 public class BufferedSavingStrategy<T> implements DataSavingStrategy<T> {
     private final Consumer<T> createSaveFunction;
     private final Consumer<Collection<T>> batchSaveFunction;
     private final boolean writeThroughOnCreate;
+    private final Executor executor;
 
     public BufferedSavingStrategy(
         Consumer<T> createSaveFunction,
         Consumer<Collection<T>> batchSaveFunction,
         boolean writeThroughOnCreate
     ) {
+        this(createSaveFunction, batchSaveFunction, writeThroughOnCreate, null);
+    }
+
+    public BufferedSavingStrategy(
+        Consumer<T> createSaveFunction,
+        Consumer<Collection<T>> batchSaveFunction,
+        boolean writeThroughOnCreate,
+        Executor executor
+    ) {
         this.createSaveFunction = createSaveFunction;
         this.batchSaveFunction = batchSaveFunction;
         this.writeThroughOnCreate = writeThroughOnCreate;
+        this.executor = executor;
     }
 
     @Override
     public void save(T data) {
         if (createSaveFunction != null) {
-            createSaveFunction.accept(data);
+            dispatch(() -> createSaveFunction.accept(data));
             return;
         }
 
-        batchSaveFunction.accept(List.of(data));
+        dispatch(() -> batchSaveFunction.accept(List.of(data)));
     }
 
     @Override
@@ -35,7 +53,10 @@ public class BufferedSavingStrategy<T> implements DataSavingStrategy<T> {
             return;
         }
 
-        batchSaveFunction.accept(data);
+        // Snapshot before handing off so the batch is stable even if the
+        // caller's collection is mutated after this call returns.
+        List<T> snapshot = List.copyOf(data);
+        dispatch(() -> batchSaveFunction.accept(snapshot));
     }
 
     @Override
@@ -46,5 +67,13 @@ public class BufferedSavingStrategy<T> implements DataSavingStrategy<T> {
     @Override
     public boolean writesThroughOnCreate() {
         return writeThroughOnCreate;
+    }
+
+    private void dispatch(Runnable write) {
+        if (executor != null) {
+            executor.execute(write);
+            return;
+        }
+        write.run();
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/ImmediateSavingStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/ImmediateSavingStrategy.java
@@ -1,22 +1,39 @@
 package com.oheers.fish.database.data.strategy;
 
 import java.util.Collection;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
+/**
+ * Persists each value as soon as it is saved. When an executor is supplied,
+ * the write itself is dispatched to that executor so the caller (typically
+ * the server thread) never blocks on database I/O; writes still happen in
+ * submission order.
+ */
 public class ImmediateSavingStrategy<T> implements DataSavingStrategy<T> {
     private final Consumer<T> saveFunction;
+    private final Executor executor;
 
     public ImmediateSavingStrategy(Consumer<T> saveFunction) {
+        this(saveFunction, null);
+    }
+
+    public ImmediateSavingStrategy(Consumer<T> saveFunction, Executor executor) {
         this.saveFunction = saveFunction;
+        this.executor = executor;
     }
 
     @Override
     public void save(T data) {
-        saveFunction.accept(data); // Save immediately
+        if (executor != null) {
+            executor.execute(() -> saveFunction.accept(data));
+            return;
+        }
+        saveFunction.accept(data);
     }
 
     @Override
     public void saveAll(Collection<T> data) {
-        data.forEach(this::save); // Save each item immediately
+        data.forEach(this::save);
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/CompetitionSavingStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/CompetitionSavingStrategy.java
@@ -5,12 +5,15 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.database.data.strategy.BufferedSavingStrategy;
 import com.oheers.fish.database.model.CompetitionReport;
 
+import java.util.concurrent.Executor;
+
 public class CompetitionSavingStrategy extends BufferedSavingStrategy<CompetitionReport> {
-    public CompetitionSavingStrategy() {
+    public CompetitionSavingStrategy(Executor executor) {
         super(
             competition -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().updateCompetition(competition),
             competitions -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().batchUpdateCompetitions(competitions),
-            true
+            true,
+            executor
         );
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/FishLogSavingStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/FishLogSavingStrategy.java
@@ -6,9 +6,10 @@ import com.oheers.fish.database.data.strategy.ImmediateSavingStrategy;
 import com.oheers.fish.database.model.fish.FishLog;
 
 import java.util.Collection;
+import java.util.concurrent.Executor;
 
 public class FishLogSavingStrategy extends ImmediateSavingStrategy<Collection<FishLog>> {
-    public FishLogSavingStrategy() {
-        super(logs -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().batchInsertFishLogs(logs));
+    public FishLogSavingStrategy(Executor executor) {
+        super(logs -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().batchInsertFishLogs(logs), executor);
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/FishStatsSavingStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/FishStatsSavingStrategy.java
@@ -4,9 +4,11 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.database.data.strategy.ImmediateSavingStrategy;
 import com.oheers.fish.database.model.fish.FishStats;
 
+import java.util.concurrent.Executor;
+
 
 public class FishStatsSavingStrategy extends ImmediateSavingStrategy<FishStats> {
-    public FishStatsSavingStrategy() {
-        super(fishStats -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().upsertFishStats(fishStats));
+    public FishStatsSavingStrategy(Executor executor) {
+        super(fishStats -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().upsertFishStats(fishStats), executor);
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/UserFishStatsSavingStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/UserFishStatsSavingStrategy.java
@@ -4,12 +4,15 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.database.data.strategy.BufferedSavingStrategy;
 import com.oheers.fish.database.model.user.UserFishStats;
 
+import java.util.concurrent.Executor;
+
 public class UserFishStatsSavingStrategy extends BufferedSavingStrategy<UserFishStats> {
-    public UserFishStatsSavingStrategy() {
+    public UserFishStatsSavingStrategy(Executor executor) {
         super(
             stats -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().upsertUserFishStats(stats),
             stats -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().batchUpdateUserFishStats(stats),
-            true
+            true,
+            executor
         );
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/UserReportsSavingStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/strategy/impl/UserReportsSavingStrategy.java
@@ -5,9 +5,11 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.database.data.strategy.ImmediateSavingStrategy;
 import com.oheers.fish.database.model.user.UserReport;
 
+import java.util.concurrent.Executor;
+
 
 public class UserReportsSavingStrategy extends ImmediateSavingStrategy<UserReport> {
-    public UserReportsSavingStrategy() {
-        super(report -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().upsertUserReport(report));
+    public UserReportsSavingStrategy(Executor executor) {
+        super(report -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().upsertUserReport(report), executor);
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/EMFFishListener.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/EMFFishListener.java
@@ -84,16 +84,22 @@ public class EMFFishListener implements Listener {
         final String key = fishRarityKey.toString();
         FishStats stats = fishStatsDataManager.peek(key);
         if (stats == null) {
-            final var loadResult = EvenMoreFish.getInstance().getPluginDataManager().getDatabase().loadFishStats(fish.getName(), fish.getRarity().getId());
-            if (loadResult.isUnreadable()) {
-                EvenMoreFish.getInstance().getLogger().warning("Skipping fish stats update for " + key + " because the stored row could not be read.");
-                return;
-            }
-            if (loadResult.isFound()) {
-                stats = loadResult.getValue();
-                fishStatsDataManager.cacheLoadedValue(key, stats);
-            } else {
+            if (EvenMoreFish.getInstance().getPluginDataManager().isFishStatsPreloaded()) {
+                // Every stored row is already cached, so a miss means the
+                // fish has never been caught — no blocking lookup needed.
                 stats = FishStats.empty(fish, LocalDateTime.now());
+            } else {
+                final var loadResult = EvenMoreFish.getInstance().getPluginDataManager().getDatabase().loadFishStats(fish.getName(), fish.getRarity().getId());
+                if (loadResult.isUnreadable()) {
+                    EvenMoreFish.getInstance().getLogger().warning("Skipping fish stats update for " + key + " because the stored row could not be read.");
+                    return;
+                }
+                if (loadResult.isFound()) {
+                    stats = loadResult.getValue();
+                    fishStatsDataManager.cacheLoadedValue(key, stats);
+                } else {
+                    stats = FishStats.empty(fish, LocalDateTime.now());
+                }
             }
         }
 
@@ -129,16 +135,22 @@ public class EMFFishListener implements Listener {
         final String key = UserFishRarityKey.of(userId,fish).toString();
         UserFishStats stats = userFishStatsDataManager.peek(key);
         if (stats == null) {
-            final var loadResult = EvenMoreFish.getInstance().getPluginDataManager().getDatabase().loadUserFishStats(userId, fish.getName(), fish.getRarity().getId());
-            if (loadResult.isUnreadable()) {
-                EvenMoreFish.getInstance().getLogger().warning("Skipping user fish stats update for " + key + " because the stored row could not be read.");
-                return;
-            }
-            if (loadResult.isFound()) {
-                stats = loadResult.getValue();
-                userFishStatsDataManager.cacheLoadedValue(key, stats);
-            } else {
+            if (EvenMoreFish.getInstance().getPluginDataManager().isUserFishStatsPreloaded(userId)) {
+                // All of this user's rows are already cached, so a miss means
+                // a first catch of this fish — no blocking lookup needed.
                 stats = new UserFishStats(userId, fish, LocalDateTime.now());
+            } else {
+                final var loadResult = EvenMoreFish.getInstance().getPluginDataManager().getDatabase().loadUserFishStats(userId, fish.getName(), fish.getRarity().getId());
+                if (loadResult.isUnreadable()) {
+                    EvenMoreFish.getInstance().getLogger().warning("Skipping user fish stats update for " + key + " because the stored row could not be read.");
+                    return;
+                }
+                if (loadResult.isFound()) {
+                    stats = loadResult.getValue();
+                    userFishStatsDataManager.cacheLoadedValue(key, stats);
+                } else {
+                    stats = new UserFishStats(userId, fish, LocalDateTime.now());
+                }
             }
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
@@ -97,7 +97,7 @@ public class FishJournalGui extends ConfigGui {
 
         boolean hideUndiscovered = section.getBoolean("hide-undiscovered-fish", true);
         // If undiscovered fish should be hidden
-        if (hideUndiscovered && !database.userHasFish(fish.getRarity().getId(), fish.getName(), userId)) {
+        if (hideUndiscovered && !userHasFish(database, fish)) {
             return ItemFactory.itemFactory(section, "undiscovered-fish").createItem(player.getUniqueId());
         }
 
@@ -125,9 +125,30 @@ public class FishJournalGui extends ConfigGui {
         return display;
     }
 
+    /**
+     * Answers "has this user caught this fish" from the preloaded cache when
+     * possible, so opening the journal does not run one blocking query per
+     * fish on the server thread.
+     */
+    private boolean userHasFish(@NotNull Database database, @NotNull Fish fish) {
+        final var dataManager = EvenMoreFish.getInstance().getPluginDataManager();
+        if (dataManager.isUserFishStatsPreloaded(userId)) {
+            return dataManager.getUserFishStatsDataManager().peek(UserFishRarityKey.of(userId, fish).toString()) != null;
+        }
+        return database.userHasFish(fish.getRarity().getId(), fish.getName(), userId);
+    }
+
     private @NotNull EMFListMessage prepareLore(@NotNull ItemFactory factory, @NotNull Fish fish) {
-        final UserFishStats userFishStats = EvenMoreFish.getInstance().getPluginDataManager().getUserFishStatsDataManager().get(UserFishRarityKey.of(userId, fish).toString());
-        final FishStats fishStats = EvenMoreFish.getInstance().getPluginDataManager().getFishStatsDataManager().get(FishRarityKey.of(fish).toString());
+        final var dataManager = EvenMoreFish.getInstance().getPluginDataManager();
+        // When the caches were preloaded, a miss means "no row exists" and
+        // falling through to the blocking loader would query the database
+        // once per fish while the GUI builds on the server thread.
+        final UserFishStats userFishStats = dataManager.isUserFishStatsPreloaded(userId)
+            ? dataManager.getUserFishStatsDataManager().peek(UserFishRarityKey.of(userId, fish).toString())
+            : dataManager.getUserFishStatsDataManager().get(UserFishRarityKey.of(userId, fish).toString());
+        final FishStats fishStats = dataManager.isFishStatsPreloaded()
+            ? dataManager.getFishStatsDataManager().peek(FishRarityKey.of(fish).toString())
+            : dataManager.getFishStatsDataManager().get(FishRarityKey.of(fish).toString());
 
         final String discoverDate = getValueOrDefault(() -> userFishStats.getFirstCatchTime().format(DateTimeFormatter.ISO_DATE), getUnknownMessage());
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/PluginDataManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/PluginDataManager.java
@@ -5,6 +5,7 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.database.Database;
 import com.oheers.fish.database.DatabaseUtil;
+import com.oheers.fish.database.data.DatabaseWriteQueue;
 import com.oheers.fish.database.data.FishLogKey;
 import com.oheers.fish.database.data.FishRarityKey;
 import com.oheers.fish.database.data.UserFishRarityKey;
@@ -31,6 +32,7 @@ public class PluginDataManager {
     private final EvenMoreFish plugin;
     private Database database;
     private UserManager userManager;
+    private DatabaseWriteQueue writeQueue;
 
     // Data Managers
     private DataManager<Collection<FishLog>> fishLogDataManager;
@@ -52,22 +54,23 @@ public class PluginDataManager {
         }
 
         this.database = new Database();
+        this.writeQueue = new DatabaseWriteQueue();
         initDataManagers();
     }
 
     public void initDataManagers() {
-        this.userManager = new UserManager(database);
-        this.fishLogDataManager = new DataManager<>(new FishLogSavingStrategy(), key -> {
+        this.userManager = new UserManager(database, writeQueue, null);
+        this.fishLogDataManager = new DataManager<>(new FishLogSavingStrategy(writeQueue), key -> {
             FishLogKey logKey = FishLogKey.from(key);
             return Collections.singleton(database.getFishLog(logKey.getUserId(), logKey.getFishName(), logKey.getFishRarity(), logKey.getDateTime()));
         });
-        this.fishStatsDataManager = new DataManager<>(new FishStatsSavingStrategy(), key -> {
+        this.fishStatsDataManager = new DataManager<>(new FishStatsSavingStrategy(writeQueue), key -> {
             final FishRarityKey fishRarityKey = FishRarityKey.from(key);
             return database.getFishStats(fishRarityKey.fishName(),fishRarityKey.fishRarity());
         });
 
         this.userFishStatsDataManager = new DataManager<UserFishStats>(
-            new UserFishStatsSavingStrategy(),
+            new UserFishStatsSavingStrategy(writeQueue),
             key -> {
                 final UserFishRarityKey userFishRarityKey = UserFishRarityKey.from(key);
                 return database.getUserFishStats(userFishRarityKey.userId(), userFishRarityKey.fishName(), userFishRarityKey.fishRarity());
@@ -76,9 +79,9 @@ public class PluginDataManager {
             TimeUnit.valueOf(MainConfig.getInstance().getSaveIntervalUnit())
         );
 
-        this.userReportDataManager = new DataManager<>(new UserReportsSavingStrategy(), uuid -> database.getUserReport(UUID.fromString(uuid)));
+        this.userReportDataManager = new DataManager<>(new UserReportsSavingStrategy(writeQueue), uuid -> database.getUserReport(UUID.fromString(uuid)));
         this.competitionDataManager = new DataManager<CompetitionReport>(
-            new CompetitionSavingStrategy(),
+            new CompetitionSavingStrategy(writeQueue),
             key -> database.getCompetitionReport(Integer.parseInt(key)),
             Long.valueOf(MainConfig.getInstance().getCompetitionSaveInterval()),
             TimeUnit.valueOf(MainConfig.getInstance().getSaveIntervalUnit())
@@ -91,11 +94,19 @@ public class PluginDataManager {
         }
 
         try {
-            // Flush all pending data
+            // Flush all pending data. The managers enqueue their remaining
+            // writes onto the write queue.
             userReportDataManager.shutdown();
             userFishStatsDataManager.shutdown();
             fishStatsDataManager.shutdown();
+            fishLogDataManager.shutdown();
             competitionDataManager.shutdown();
+
+            // Drain the write queue before closing the pool so no queued
+            // writes are lost. Blocking here (onDisable) is acceptable.
+            if (writeQueue != null) {
+                writeQueue.shutdown(60, TimeUnit.SECONDS);
+            }
 
             // Close database connection
             database.shutdown();
@@ -131,6 +142,13 @@ public class PluginDataManager {
 
     public Database getDatabase() {
         return database;
+    }
+
+    /**
+     * The single-threaded queue all database writes are dispatched to.
+     */
+    public DatabaseWriteQueue getWriteQueue() {
+        return writeQueue;
     }
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/PluginDataManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/PluginDataManager.java
@@ -24,7 +24,10 @@ import com.oheers.fish.database.model.user.UserReport;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -33,6 +36,12 @@ public class PluginDataManager {
     private Database database;
     private UserManager userManager;
     private DatabaseWriteQueue writeQueue;
+
+    // Users whose fish stats rows have been fully preloaded into the cache,
+    // so a cache miss on the server thread means "no row exists" and no
+    // blocking existence query is needed.
+    private final Set<Integer> preloadedUserFishStats = ConcurrentHashMap.newKeySet();
+    private volatile boolean fishStatsPreloaded;
 
     // Data Managers
     private DataManager<Collection<FishLog>> fishLogDataManager;
@@ -56,10 +65,11 @@ public class PluginDataManager {
         this.database = new Database();
         this.writeQueue = new DatabaseWriteQueue();
         initDataManagers();
+        writeQueue.execute(this::preloadFishStats);
     }
 
     public void initDataManagers() {
-        this.userManager = new UserManager(database, writeQueue, null);
+        this.userManager = new UserManager(database, writeQueue, this::preloadUserData);
         this.fishLogDataManager = new DataManager<>(new FishLogSavingStrategy(writeQueue), key -> {
             FishLogKey logKey = FishLogKey.from(key);
             return Collections.singleton(database.getFishLog(logKey.getUserId(), logKey.getFishName(), logKey.getFishRarity(), logKey.getDateTime()));
@@ -149,6 +159,61 @@ public class PluginDataManager {
      */
     public DatabaseWriteQueue getWriteQueue() {
         return writeQueue;
+    }
+
+    /**
+     * True once every row of the global fish stats table has been loaded
+     * into the cache, meaning a cache miss can be treated as "row does not
+     * exist" without a blocking query.
+     */
+    public boolean isFishStatsPreloaded() {
+        return fishStatsPreloaded;
+    }
+
+    /**
+     * True once all of the user's fish stats rows have been loaded into the
+     * cache, meaning a cache miss for that user can be treated as "row does
+     * not exist" without a blocking query.
+     */
+    public boolean isUserFishStatsPreloaded(int userId) {
+        return preloadedUserFishStats.contains(userId);
+    }
+
+    /**
+     * Runs on the write queue after the user's row is guaranteed to exist:
+     * warms the user report and user fish stats caches so the catch path on
+     * the server thread never needs a blocking load.
+     */
+    private void preloadUserData(UUID uuid, int userId) {
+        UserReport report = database.getUserReport(uuid);
+        if (report != null) {
+            userReportDataManager.cacheLoadedValue(uuid.toString(), report);
+        }
+
+        List<UserFishStats> statsRows = database.loadAllUserFishStats(userId);
+        if (statsRows != null) {
+            for (UserFishStats stats : statsRows) {
+                userFishStatsDataManager.cacheLoadedValue(
+                    UserFishRarityKey.of(userId, stats.getFishName(), stats.getFishRarity()).toString(),
+                    stats
+                );
+            }
+            preloadedUserFishStats.add(userId);
+        }
+    }
+
+    private void preloadFishStats() {
+        List<FishStats> rows = database.loadAllFishStats();
+        if (rows == null) {
+            plugin.getLogger().warning("Could not preload fish stats; falling back to on-demand loads.");
+            return;
+        }
+
+        for (FishStats stats : rows) {
+            fishStatsDataManager.cacheLoadedValue(FishRarityKey.of(stats.getFishName(), stats.getFishRarity()).toString(), stats);
+        }
+        fishStatsPreloaded = true;
+        plugin.getLogger().info("Preloaded %d fish stats entries.".formatted(rows.size()));
     }
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
@@ -180,15 +180,19 @@ public class SellHelper {
 
         Database database = EvenMoreFish.getInstance().getPluginDataManager().getDatabase();
 
-        database.createTransaction(transactionId, userId, timestamp);
-        soldFish.forEach(fish -> database.createSale(
-            transactionId,
-            fish.getName(),
-            fish.getRarity(),
-            fish.getAmount(),
-            fish.getLength(),
-            fish.getTotalValue()
-        ));
+        // Insert the transaction and sale rows off the server thread; the
+        // queue keeps the transaction row ahead of its sale rows.
+        EvenMoreFish.getInstance().getPluginDataManager().getWriteQueue().execute(() -> {
+            database.createTransaction(transactionId, userId, timestamp);
+            soldFish.forEach(fish -> database.createSale(
+                transactionId,
+                fish.getName(),
+                fish.getRarity(),
+                fish.getAmount(),
+                fish.getLength(),
+                fish.getTotalValue()
+            ));
+        });
 
         final DataManager<UserReport> userReportDataManager = EvenMoreFish.getInstance().getPluginDataManager().getUserReportDataManager();
         final UserReport report = userReportDataManager.get(uuid.toString());

--- a/even-more-fish-plugin/src/test/java/com/oheers/fish/database/data/DatabaseWriteQueueTest.java
+++ b/even-more-fish-plugin/src/test/java/com/oheers/fish/database/data/DatabaseWriteQueueTest.java
@@ -1,0 +1,81 @@
+package com.oheers.fish.database.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatabaseWriteQueueTest {
+
+    @Test
+    void executesTasksOffTheCallerThreadInSubmissionOrder() throws Exception {
+        DatabaseWriteQueue queue = new DatabaseWriteQueue();
+        List<Integer> order = new CopyOnWriteArrayList<>();
+        AtomicReference<Thread> workerThread = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+
+        IntStream.range(0, 100).forEach(i -> queue.execute(() -> order.add(i)));
+        queue.execute(() -> {
+            workerThread.set(Thread.currentThread());
+            done.countDown();
+        });
+
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertEquals(IntStream.range(0, 100).boxed().toList(), order);
+        assertNotEquals(Thread.currentThread(), workerThread.get());
+        assertTrue(workerThread.get().getName().startsWith("emf-db-writer-"));
+        assertTrue(queue.shutdown(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void shutdownDrainsAllQueuedWrites() {
+        DatabaseWriteQueue queue = new DatabaseWriteQueue();
+        List<Integer> executed = new CopyOnWriteArrayList<>();
+
+        IntStream.range(0, 50).forEach(i -> queue.execute(() -> {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            executed.add(i);
+        }));
+
+        assertTrue(queue.shutdown(10, TimeUnit.SECONDS));
+        assertEquals(50, executed.size());
+    }
+
+    @Test
+    void writeSubmittedAfterShutdownRunsInlineInsteadOfBeingLost() {
+        DatabaseWriteQueue queue = new DatabaseWriteQueue();
+        assertTrue(queue.shutdown(5, TimeUnit.SECONDS));
+
+        AtomicReference<Thread> executionThread = new AtomicReference<>();
+        queue.execute(() -> executionThread.set(Thread.currentThread()));
+
+        assertEquals(Thread.currentThread(), executionThread.get());
+    }
+
+    @Test
+    void failingWriteDoesNotStopSubsequentWrites() {
+        DatabaseWriteQueue queue = new DatabaseWriteQueue();
+        AtomicBoolean secondRan = new AtomicBoolean(false);
+
+        queue.execute(() -> {
+            throw new IllegalStateException("simulated write failure");
+        });
+        queue.execute(() -> secondRan.set(true));
+
+        assertTrue(queue.shutdown(5, TimeUnit.SECONDS));
+        assertTrue(secondRan.get());
+    }
+}

--- a/even-more-fish-plugin/src/test/java/com/oheers/fish/database/data/strategy/AsyncSavingStrategyTest.java
+++ b/even-more-fish-plugin/src/test/java/com/oheers/fish/database/data/strategy/AsyncSavingStrategyTest.java
@@ -1,0 +1,98 @@
+package com.oheers.fish.database.data.strategy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AsyncSavingStrategyTest {
+
+    /**
+     * Records submitted tasks without running them, so tests can assert
+     * that nothing executed on the caller thread and then run the backlog.
+     */
+    private static final class DeferredExecutor implements Executor {
+        private final List<Runnable> tasks = new ArrayList<>();
+
+        @Override
+        public void execute(Runnable command) {
+            tasks.add(command);
+        }
+
+        void runAll() {
+            tasks.forEach(Runnable::run);
+            tasks.clear();
+        }
+    }
+
+    @Test
+    void immediateStrategyDispatchesSavesToExecutor() {
+        DeferredExecutor executor = new DeferredExecutor();
+        List<String> saved = new ArrayList<>();
+        ImmediateSavingStrategy<String> strategy = new ImmediateSavingStrategy<>(saved::add, executor);
+
+        strategy.save("a");
+        strategy.saveAll(List.of("b", "c"));
+
+        assertTrue(saved.isEmpty(), "saves must not run on the caller thread");
+        executor.runAll();
+        assertEquals(List.of("a", "b", "c"), saved);
+    }
+
+    @Test
+    void immediateStrategyWithoutExecutorSavesInline() {
+        List<String> saved = new ArrayList<>();
+        ImmediateSavingStrategy<String> strategy = new ImmediateSavingStrategy<>(saved::add);
+
+        strategy.save("a");
+
+        assertEquals(List.of("a"), saved);
+    }
+
+    @Test
+    void bufferedStrategyDispatchesCreateAndBatchWritesToExecutor() {
+        DeferredExecutor executor = new DeferredExecutor();
+        List<String> createWrites = new ArrayList<>();
+        List<List<String>> batchWrites = new ArrayList<>();
+        BufferedSavingStrategy<String> strategy = new BufferedSavingStrategy<>(
+            createWrites::add,
+            batch -> batchWrites.add(new ArrayList<>(batch)),
+            true,
+            executor
+        );
+
+        strategy.save("created");
+        strategy.saveAll(List.of("x", "y"));
+
+        assertTrue(createWrites.isEmpty());
+        assertTrue(batchWrites.isEmpty());
+        executor.runAll();
+        assertEquals(List.of("created"), createWrites);
+        assertEquals(List.of(List.of("x", "y")), batchWrites);
+    }
+
+    @Test
+    void bufferedStrategySnapshotsBatchesBeforeHandoff() {
+        DeferredExecutor executor = new DeferredExecutor();
+        List<Collection<String>> batchWrites = new ArrayList<>();
+        BufferedSavingStrategy<String> strategy = new BufferedSavingStrategy<>(
+            null,
+            batchWrites::add,
+            false,
+            executor
+        );
+
+        List<String> source = new ArrayList<>(List.of("x", "y"));
+        strategy.saveAll(source);
+        source.clear();
+        executor.runAll();
+
+        assertEquals(1, batchWrites.size());
+        assertEquals(List.of("x", "y"), List.copyOf(batchWrites.getFirst()));
+    }
+}


### PR DESCRIPTION
## Description
Moves all EMF database writes off the main thread. Every fish catch currently does blocking DB round-trips on the tick thread (`upsertFishStats` / `batchInsertFishLogs` / `upsertUserReport`, reached from the catch listener via `ImmediateSavingStrategy.save`); when the database is slow - remote/high-latency especially - that blocking surfaces as watchdog freezes.

---

### What has changed?
- **New `DatabaseWriteQueue`** - a single-threaded daemon executor. All writes go through it FIFO; a failed write is logged and doesn't kill the thread. On disable it drains the backlog (60s cap) before Hikari closes; writes submitted after shutdown run inline so nothing is lost.
- **Saving strategies + `SellHelper`** dispatch their writes to the queue instead of running them inline.
- **Cache preloading** for the catch path: global fish stats at startup, the joining player's rows on join (both off-thread). With those warm, a cache miss means "row doesn't exist", so no blocking SELECT runs on the tick thread; the old on-demand load stays as a fallback only if a preload failed.
- **Hikari hardening** in `ConnectionFactory`: `connectionTimeout` 5s (was 30s), `keepaliveTime` 1m to keep connections warm, dropped the borrow-time validation ping.

Config, Flyway migrations and schema are unchanged - drop-in. Trade-off: writes are now eventually consistent, so a hard crash can lose whatever is still queued (a clean stop drains it).

---

### Related Issues
No linked issue - addresses main-thread stalls from synchronous database I/O on the fish-catch path.

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed. <!-- no doc changes needed: config, schema, and commands are unchanged -->