### PR TITLE
Add API for external rarity weight boosts

### DIFF
--- a/docs/docs/developers/rarity-boosts.md
+++ b/docs/docs/developers/rarity-boosts.md
@@ -1,0 +1,70 @@
+---
+title: Boosting Rarity Chances
+sidebar_position: 4
+---
+
+## What are rarity boosts?
+
+The [RarityWeightBoost](https://github.com/EvenMoreFish/EvenMoreFish/blob/master/even-more-fish-api/src/main/java/com/oheers/fish/api/boost/RarityWeightBoost.java)
+interface lets your plugin change the chance of specific rarities being rolled, per catch.
+Every time EvenMoreFish picks a rarity, it asks each registered boost for a weight multiplier
+for each candidate rarity:
+
+- `1.0` leaves the rarity unchanged,
+- values above `1.0` make it more likely,
+- values between `0.0` and `1.0` make it less likely.
+
+When several plugins register boosts, their multipliers are combined by multiplication.
+
+This makes it easy to build things like area-of-effect fishing buffs, timed events or
+custom enchantments that improve catches, without touching EvenMoreFish's configs.
+
+## Example
+
+```java
+public class LuckyHourBoost implements RarityWeightBoost {
+
+    /**
+     * A unique key for this boost, conventionally your plugin's name.
+     */
+    @Override
+    public @NotNull String getKey() {
+        return "MyPlugin";
+    }
+
+    /**
+     * Called on the server thread for every candidate rarity of every catch,
+     * so keep this fast and never touch blocking IO.
+     */
+    @Override
+    public double weightMultiplier(@NotNull Player fisher, @NotNull Location location, @NotNull String rarityId) {
+        // Double the legendary chance while the lucky hour is active.
+        if (isLuckyHour() && rarityId.equals("legendary")) {
+            return 2.0;
+        }
+        return 1.0;
+    }
+}
+```
+
+The `rarityId` is the id of the rarity as configured in EvenMoreFish's `rarities` folder
+(for example `common`, `rare`, `epic` or `legendary`).
+
+## Registering your boost
+
+Register the boost when your plugin enables and unregister it when it disables:
+
+```java
+@Override
+public void onEnable() {
+    RarityBoostRegistry.getInstance().register(new LuckyHourBoost());
+}
+
+@Override
+public void onDisable() {
+    RarityBoostRegistry.getInstance().unregister("MyPlugin");
+}
+```
+
+Your plugin should declare `depend` or `softdepend` on `EvenMoreFish` in its `plugin.yml`
+so the api classes are available when it loads.

--- a/even-more-fish-api/build.gradle.kts
+++ b/even-more-fish-api/build.gradle.kts
@@ -56,6 +56,12 @@ testing {
             dependencies {
                 implementation(libs.junit.jupiter.api)
                 runtimeOnly(libs.junit.jupiter.engine)
+                implementation(libs.mockito.core)
+                implementation(libs.paper.api) {
+                    version {
+                        strictly("1.20.1-R0.1-SNAPSHOT")
+                    }
+                }
             }
 
             targets {

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/boost/RarityBoostRegistry.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/boost/RarityBoostRegistry.java
@@ -1,0 +1,118 @@
+package com.oheers.fish.api.boost;
+
+import com.oheers.fish.api.plugin.EMFPlugin;
+import com.oheers.fish.api.registry.EMFRegistry;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Registry of external {@link RarityWeightBoost}s applied when EvenMoreFish rolls a rarity.
+ * <p>
+ * Other plugins register a boost on enable and unregister it on disable. When several
+ * boosts are registered, their multipliers are combined by multiplication.
+ */
+public class RarityBoostRegistry implements EMFRegistry<RarityWeightBoost> {
+
+    private static final RarityBoostRegistry instance = new RarityBoostRegistry();
+
+    private final Map<String, RarityWeightBoost> registry = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    private RarityBoostRegistry() {}
+
+    public static @NotNull RarityBoostRegistry getInstance() {
+        return instance;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return registry.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+        registry.clear();
+    }
+
+    /**
+     * @return An immutable copy of the current registry.
+     */
+    @Override
+    public @NotNull Map<String, RarityWeightBoost> getRegistry() {
+        return Map.copyOf(registry);
+    }
+
+    /**
+     * Get a value from the registry.
+     *
+     * @param key The key to look for.
+     * @return The value, or null if not found.
+     */
+    @Override
+    public @Nullable RarityWeightBoost get(@NotNull String key) {
+        return registry.get(key);
+    }
+
+    /**
+     * Get a value from the registry, or a default value if not found.
+     *
+     * @param key          The key to look for.
+     * @param defaultValue The default value to return if not found.
+     * @return The value, or the default value if not found.
+     */
+    @Override
+    public @NotNull RarityWeightBoost getOrDefault(@NotNull String key, @NotNull RarityWeightBoost defaultValue) {
+        return registry.getOrDefault(key, defaultValue);
+    }
+
+    /**
+     * Unregister a key from the registry.
+     *
+     * @param key The key to unregister.
+     * @return True if the key was unregistered, false if not found.
+     */
+    @Override
+    public boolean unregister(@NotNull String key) {
+        return registry.remove(key) != null;
+    }
+
+    /**
+     * Register a value in the registry.
+     *
+     * @param value The value to register.
+     * @param force Whether to force the registration, overwriting any existing value.
+     * @return True if the value was registered, false if a value with the same key already exists and force is false.
+     */
+    @Override
+    public boolean register(@NotNull RarityWeightBoost value, boolean force) {
+        if (!force && registry.containsKey(value.getKey())) {
+            return false;
+        }
+        registry.put(value.getKey(), value);
+        EMFPlugin.getInstance().debug("Registered " + value.getKey() + " RarityWeightBoost");
+        return true;
+    }
+
+    /**
+     * The combined weight multiplier for one candidate rarity of one catch: the product of
+     * every registered boost's multiplier. Negative results from misbehaving boosts are
+     * clamped to zero so a bad registration can never produce negative weights.
+     *
+     * @param fisher   The player catching the fish.
+     * @param location The location the fish is being caught at.
+     * @param rarityId The id of the candidate rarity.
+     * @return The combined multiplier, {@code 1.0} when no boosts are registered.
+     */
+    public double combinedMultiplier(@NotNull Player fisher, @NotNull Location location, @NotNull String rarityId) {
+        double combined = 1.0;
+        for (RarityWeightBoost boost : registry.values()) {
+            combined *= boost.weightMultiplier(fisher, location, rarityId);
+        }
+        return Math.max(0.0, combined);
+    }
+
+}

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/boost/RarityWeightBoost.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/boost/RarityWeightBoost.java
@@ -1,0 +1,33 @@
+package com.oheers.fish.api.boost;
+
+import com.oheers.fish.api.registry.RegistryItem;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An external modifier consulted every time EvenMoreFish rolls a rarity for a catch.
+ * <p>
+ * Implementations are registered with the {@link RarityBoostRegistry} by other plugins
+ * (for example area-of-effect fishing buffs) and return a multiplier that is applied to
+ * a rarity's configured weight for a single roll. The {@link #getKey() key} should be
+ * the registering plugin's name.
+ */
+public interface RarityWeightBoost extends RegistryItem {
+
+    /**
+     * Returns the multiplier to apply to a rarity's configured weight for one catch.
+     * <p>
+     * Called on the server thread for every candidate rarity of every catch, so
+     * implementations must be fast and must not touch blocking IO.
+     *
+     * @param fisher   The player catching the fish.
+     * @param location The location the fish is being caught at (the hook location).
+     * @param rarityId The id of the candidate rarity, as configured in the rarities folder.
+     * @return The weight multiplier; {@code 1.0} leaves the rarity unchanged, values above
+     *         {@code 1.0} make it more likely, values between {@code 0.0} and {@code 1.0}
+     *         make it less likely. Must not be negative.
+     */
+    double weightMultiplier(@NotNull Player fisher, @NotNull Location location, @NotNull String rarityId);
+
+}

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/registry/EMFRegistry.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/registry/EMFRegistry.java
@@ -1,6 +1,7 @@
 package com.oheers.fish.api.registry;
 
 import com.oheers.fish.api.addons.ItemAddonRegistry;
+import com.oheers.fish.api.boost.RarityBoostRegistry;
 import com.oheers.fish.api.economy.EconomyTypeRegistry;
 import com.oheers.fish.api.requirement.RequirementTypeRegistry;
 import com.oheers.fish.api.reward.RewardTypeRegistry;
@@ -15,6 +16,7 @@ public interface EMFRegistry<T extends RegistryItem> {
     @NotNull RewardTypeRegistry REWARD_TYPE = RewardTypeRegistry.getInstance();
     @NotNull ItemAddonRegistry ITEM_ADDON = ItemAddonRegistry.getInstance();
     @NotNull EconomyTypeRegistry ECONOMY_TYPE = EconomyTypeRegistry.getInstance();
+    @NotNull RarityBoostRegistry RARITY_BOOST = RarityBoostRegistry.getInstance();
 
     boolean isEmpty();
 

--- a/even-more-fish-api/src/test/java/com/oheers/fish/api/boost/RarityBoostRegistryTest.java
+++ b/even-more-fish-api/src/test/java/com/oheers/fish/api/boost/RarityBoostRegistryTest.java
@@ -1,0 +1,118 @@
+package com.oheers.fish.api.boost;
+
+import com.oheers.fish.api.plugin.EMFPlugin;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jetbrains.annotations.NotNull;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RarityBoostRegistryTest {
+
+    private final RarityBoostRegistry registry = RarityBoostRegistry.getInstance();
+    private final Player fisher = Mockito.mock(Player.class);
+    private final Location location = new Location(null, 0, 0, 0);
+
+    @BeforeAll
+    static void setUpPluginInstance() throws ReflectiveOperationException {
+        setPluginInstance(Mockito.mock(EMFPlugin.class));
+    }
+
+    @AfterAll
+    static void tearDownPluginInstance() throws ReflectiveOperationException {
+        setPluginInstance(null);
+    }
+
+    /** Registering logs through the plugin singleton, which does not exist in unit tests. */
+    private static void setPluginInstance(EMFPlugin plugin) throws ReflectiveOperationException {
+        Field instance = EMFPlugin.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, plugin);
+    }
+
+    @BeforeEach
+    void clearRegistry() {
+        registry.clear();
+    }
+
+    @Test
+    void registerAndUnregister() {
+        RarityWeightBoost boost = fixedBoost("BoostPlugin", 2.0);
+
+        assertTrue(registry.register(boost));
+        assertSame(boost, registry.get("BoostPlugin"));
+        assertFalse(registry.isEmpty());
+
+        assertFalse(registry.register(fixedBoost("BoostPlugin", 3.0)), "duplicate keys should not register");
+        assertTrue(registry.register(fixedBoost("BoostPlugin", 3.0), true), "force should overwrite");
+
+        assertTrue(registry.unregister("BoostPlugin"));
+        assertFalse(registry.unregister("BoostPlugin"));
+        assertNull(registry.get("BoostPlugin"));
+        assertTrue(registry.isEmpty());
+    }
+
+    @Test
+    void combinedMultiplierIsOneWithoutBoosts() {
+        assertEquals(1.0, registry.combinedMultiplier(fisher, location, "common"));
+    }
+
+    @Test
+    void combinedMultiplierMultipliesAllBoosts() {
+        registry.register(fixedBoost("PluginA", 2.0));
+        registry.register(fixedBoost("PluginB", 1.5));
+
+        assertEquals(3.0, registry.combinedMultiplier(fisher, location, "legendary"));
+    }
+
+    @Test
+    void combinedMultiplierPassesTheRarityId() {
+        registry.register(new RarityWeightBoost() {
+            @Override
+            public @NotNull String getKey() {
+                return "LegendaryOnly";
+            }
+
+            @Override
+            public double weightMultiplier(@NotNull Player fisher, @NotNull Location location, @NotNull String rarityId) {
+                return rarityId.equals("legendary") ? 4.0 : 1.0;
+            }
+        });
+
+        assertEquals(4.0, registry.combinedMultiplier(fisher, location, "legendary"));
+        assertEquals(1.0, registry.combinedMultiplier(fisher, location, "common"));
+    }
+
+    @Test
+    void combinedMultiplierClampsNegativeResults() {
+        registry.register(fixedBoost("Misbehaving", -5.0));
+
+        assertEquals(0.0, registry.combinedMultiplier(fisher, location, "common"));
+    }
+
+    private static RarityWeightBoost fixedBoost(String key, double multiplier) {
+        return new RarityWeightBoost() {
+            @Override
+            public @NotNull String getKey() {
+                return key;
+            }
+
+            @Override
+            public double weightMultiplier(@NotNull Player fisher, @NotNull Location location, @NotNull String rarityId) {
+                return multiplier;
+            }
+        };
+    }
+
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/FishManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/FishManager.java
@@ -3,6 +3,7 @@ package com.oheers.fish.fishing.items;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.api.Logging;
+import com.oheers.fish.api.boost.RarityBoostRegistry;
 import com.oheers.fish.api.fishing.FishingType;
 import com.oheers.fish.api.fishing.items.AbstractFishManager;
 import com.oheers.fish.api.fishing.items.IFish;
@@ -254,7 +255,8 @@ public class FishManager extends AbstractFishManager<Rarity> {
             return null;
         }
 
-        Rarity selected = selectRandomRarity(allowedRarities, boostRate, boostedRarities);
+        Rarity selected = selectRandomRarity(allowedRarities, boostRate, boostedRarities,
+                fisher, requirementContext.getLocation());
         return selected != null && isRarityAllowedInCompetition(selected) ? selected : null;
     }
 
@@ -349,14 +351,28 @@ public class FishManager extends AbstractFishManager<Rarity> {
                 (EvenMoreFish.getInstance().isRaritiesCompCheckExempt() && rarity.hasCompExemptFish());
     }
 
-    private Rarity selectRandomRarity(List<Rarity> rarities, double boostRate, Set<Rarity> boosted) {
+    private Rarity selectRandomRarity(List<Rarity> rarities, double boostRate, Set<Rarity> boosted,
+                                      @Nullable Player fisher, @Nullable Location location) {
         return WeightedRandom.pick(
                 rarities,
-                Rarity::getWeight,
+                externallyBoostedWeight(fisher, location),
                 boostRate,
                 boosted,
                 EvenMoreFish.getInstance().getRandom()
         );
+    }
+
+    /**
+     * The rarity weight function with any externally registered {@link RarityBoostRegistry}
+     * boosts (e.g. area-of-effect fishing buffs from other plugins) multiplied in. Falls back
+     * to the plain configured weight when nothing is registered or no fisher/location is known.
+     */
+    private ToDoubleFunction<Rarity> externallyBoostedWeight(@Nullable Player fisher, @Nullable Location location) {
+        RarityBoostRegistry boosts = RarityBoostRegistry.getInstance();
+        if (fisher == null || location == null || boosts.isEmpty()) {
+            return Rarity::getWeight;
+        }
+        return rarity -> rarity.getWeight() * boosts.combinedMultiplier(fisher, location, rarity.getId());
     }
 
     public @NotNull List<Rarity> getAvailableRarities(@Nullable Player fisher,


### PR DESCRIPTION
## Description
Adds a RarityWeightBoost interface and RarityBoostRegistry (exposed as EMFRegistry.RARITY_BOOST, following the existing registry conventions) that other plugins can register to modify rarity roll weights per catch. FishManager multiplies each candidate rarity's configured weight by the combined multiplier of all registered boosts, using the fisher and hook location from the requirement context.

---

### What has changed?
This enables features like area-of-effect fishing buffs, timed events or custom enchantments to influence catch outcomes without touching configs. No behaviour changes when nothing is registered.

Includes unit tests for the registry and a developer wiki page.

---

### Related Issues
None.

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.