### PR TITLE
Fix update check crash when version number has no MC suffix

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/update/UpdateChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/update/UpdateChecker.java
@@ -49,6 +49,9 @@ public class UpdateChecker {
             JSONObject latestVersion = (JSONObject) versions.getFirst();
             String version = latestVersion.get("version_number").toString();
             int mcVersionSeparatorIndex = version.lastIndexOf("-");
+            if (mcVersionSeparatorIndex == -1) {
+                return version;
+            }
             return version.substring(0, mcVersionSeparatorIndex);
         } catch (Exception e) {
             plugin.getLogger().warning("Update check failed: " + e.getMessage());


### PR DESCRIPTION
## Description
The update checker crashes on startup when the latest version published on Modrinth has a `version_number` without a `-<mc-version>` suffix, logging:

```
[EvenMoreFish] Update check failed: Range [0, -1) out of bounds for length 5
```

---

### What has changed?
`UpdateChecker#getVersion` strips the MC-version suffix with `version.substring(0, version.lastIndexOf("-"))`. When the version string contains no dash (e.g. `2.4.2`), `lastIndexOf` returns `-1` and `substring(0, -1)` throws `StringIndexOutOfBoundsException`. The fix returns the version string unchanged when no separator is present.

---

### Related Issues
Observed on EvenMoreFish 2.4.2 running Paper 26.2 (build 60) — reproducible on any server whenever the newest Modrinth release name has no dash.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.

i maayy of used a clanker to help w/ this....