### PR TITLE
Add fish catch limits

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -65,6 +65,7 @@ public class Fish implements IFish, Sortable {
     private final String displayName;
 
     private boolean showInJournal;
+    private final int catchLimit;
 
     private Fish(@NotNull Rarity rarity, @NotNull Section section) {
         this.section = section;
@@ -96,6 +97,7 @@ public class Fish implements IFish, Sortable {
         this.displayName = section.getString("displayname", factory.getDisplayName().getConfiguredValue());
 
         this.showInJournal = section.getBoolean("journal", true);
+        this.catchLimit = section.getInt("catch-limit", rarity.getCatchLimit());
 
         ItemConfig<List<Component>> lore = factory.getLore();
         if (lore.isEnabled()) {
@@ -496,6 +498,10 @@ public class Fish implements IFish, Sortable {
     @Override
     public double getWeight() {
         return weight;
+    }
+
+    public int getCatchLimit() {
+        return catchLimit;
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/FishManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/FishManager.java
@@ -10,6 +10,9 @@ import com.oheers.fish.api.fishing.items.IFish;
 import com.oheers.fish.api.requirement.RequirementContext;
 import com.oheers.fish.competition.Competition;
 import com.oheers.fish.config.MainConfig;
+import com.oheers.fish.database.DatabaseUtil;
+import com.oheers.fish.database.data.FishRarityKey;
+import com.oheers.fish.database.model.fish.FishStats;
 import com.oheers.fish.exceptions.InvalidFishException;
 import com.oheers.fish.fishing.Processor;
 import com.oheers.fish.fishing.items.config.FishConversions;
@@ -448,6 +451,7 @@ public class FishManager extends AbstractFishManager<Rarity> {
             .filter(fish -> isFishAllowedByCustomRod(fish, customRod))
             .filter(fish -> isFishAllowedByProcessor(fish, processor))
             .filter(fish -> meetsRequirements(fish, doRequirementChecks, context))
+            .filter(this::isFishWithinCatchLimit)
             .toList();
     }
 
@@ -461,7 +465,28 @@ public class FishManager extends AbstractFishManager<Rarity> {
         return isFishAllowedByCustomRod(fish, customRod) &&
                 isFishBoosted(fish, boostRate, boostedFish) &&
                 isFishAllowedByProcessor(fish, processor) &&
-                meetsRequirements(fish, doRequirements, context);
+                meetsRequirements(fish, doRequirements, context) &&
+                isFishWithinCatchLimit(fish);
+    }
+
+    private boolean isFishWithinCatchLimit(@NotNull Fish fish) {
+        int catchLimit = fish.getCatchLimit();
+        if (catchLimit <= 0 || !DatabaseUtil.isDatabaseOnline()) {
+            return true;
+        }
+
+        var dataManager = EvenMoreFish.getInstance().getPluginDataManager();
+        if (!dataManager.isFishStatsPreloaded()) {
+            return true;
+        }
+
+        FishStats stats = dataManager.getFishStatsDataManager().peek(FishRarityKey.of(fish).toString());
+        int caught = stats == null ? 0 : stats.getQuantity();
+        return hasRemainingCatches(catchLimit, caught);
+    }
+
+    static boolean hasRemainingCatches(int catchLimit, int caught) {
+        return catchLimit <= 0 || caught < catchLimit;
     }
 
     private boolean isFishAllowedByCustomRod(Fish fish, CustomRod rod) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -89,6 +89,10 @@ public class Rarity extends ConfigBase implements IRarity, Sortable {
         return getConfig().getDouble("weight");
     }
 
+    public int getCatchLimit() {
+        return getConfig().getInt("catch-limit", -1);
+    }
+
     @Override
     public boolean getBroadcastEnabled() {
         return getConfig().getBoolean("broadcast.enabled", true);

--- a/even-more-fish-plugin/src/main/resources/rarities/_example.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/_example.yml
@@ -19,6 +19,10 @@ item:
 # How likely is the rarity to be chosen? Having a greater weight means the rarity is more likely to be chosen (the total weights don't have to add to 100)
 weight: 5
 
+# Maximum number of times each fish in this rarity can be caught globally.
+# Set to -1 or 0 for unlimited catches. This can be overridden by each fish.
+catch-limit: -1
+
 # Optional: Used for sorting the fish journal if the sort type is index.
 sort-index: 0
 
@@ -150,6 +154,10 @@ fish:
 
     # How likely is this fish to be chosen? Having a greater weight means the rarity is more likely to be chosen (the total weights don't have to add to 100)
     weight: 10
+
+    # Maximum number of times this fish can be caught globally.
+    # Set to -1 or 0 for unlimited catches.
+    catch-limit: -1
 
     # You can set custom requirement for this fish to appear, all possible requirements are on the wiki: https://evenmorefish.github.io/EvenMoreFish/docs/features/requirements
     requirements:

--- a/even-more-fish-plugin/src/test/java/com/oheers/fish/fishing/items/FishManagerCatchLimitTest.java
+++ b/even-more-fish-plugin/src/test/java/com/oheers/fish/fishing/items/FishManagerCatchLimitTest.java
@@ -1,0 +1,22 @@
+package com.oheers.fish.fishing.items;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FishManagerCatchLimitTest {
+
+    @Test
+    void unlimitedCatchLimitAllowsAnyCaughtCount() {
+        assertTrue(FishManager.hasRemainingCatches(-1, 100));
+        assertTrue(FishManager.hasRemainingCatches(0, 100));
+    }
+
+    @Test
+    void positiveCatchLimitAllowsCaughtCountsBelowLimitOnly() {
+        assertTrue(FishManager.hasRemainingCatches(3, 2));
+        assertFalse(FishManager.hasRemainingCatches(3, 3));
+        assertFalse(FishManager.hasRemainingCatches(3, 4));
+    }
+}


### PR DESCRIPTION
## Description
Adds configurable global catch limits for fish, allowing server owners to cap how many times each fish can be caught.

---

### What has changed?
- Added `catch-limit` support at the rarity level, defaulting to unlimited.
- Added per-fish `catch-limit` overrides.
- Filtered fish selection so fish at or above their configured catch limit are no longer eligible.
- Used preloaded fish stats to avoid blocking database reads during fish selection.
- Documented the new option in the rarity example config.
- Added unit coverage for catch-limit boundary behavior.

---

### Related Issues
Implements #564 

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
