### PR TITLE
Enhance/reset db command

### DIFF
--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -53,4 +53,5 @@ The main command (`/emf`) can have custom aliases configured in `MainConfig`.
 | `/emf admin database repair-flyway`     | None                                | `emf.admin.debug.database.flyway`  | Attempts to repair migrations          |
 | `/emf admin database clean-flyway`      | None                                | `emf.admin.debug.database.clean`   | Cleans Flyway tables                   |
 | `/emf admin database migrate-to-latest` | None                                | `emf.admin.debug.database.migrate` | Forces migration to latest DB version  |
+| `/emf admin database reset`             | None                                | `emf.admin.debug.database.reset`   | Resets EMF DB data after reconfirming within 30 seconds |
 

--- a/docs/docs/migration/database-migration.md
+++ b/docs/docs/migration/database-migration.md
@@ -9,6 +9,8 @@ title: Database Migration
 EMF uses flyway to automatically migrate the database. Normally you shouldn't need to manually migrate the database.
 In case things breaks you can use some commands to try and fix the issues.
 
+`/emf admin database reset` is intentionally protected by a confirmation step. Run it once to arm it, then run the same command again within 30 seconds to actually clear EMF data tables.
+
 :::info[Permission `emf.admin.debug.database.flyway`] 
 :::
 
@@ -18,6 +20,13 @@ In case things breaks you can use some commands to try and fix the issues.
 | `/emf admin database repair-flyway`     | Runs the Flyway repair command                         | `emf.admin.debug.database.flyway`  |
 | `/emf admin database clean-flyway`      | Runs the Flyway clean command                          | `emf.admin.debug.database.flyway`  |
 | `/emf admin database migrate-to-latest` | Attempts to migrate the database to the latest version | `emf.admin.debug.database.migrate` |
+| `/emf admin database reset`             | Clears EMF data tables after a 30-second confirmation  | `emf.admin.debug.database.reset`   |
+
+:::danger[Dangerous command]
+
+`/emf admin database reset` removes EMF-managed database rows and resets identities. It does not use Flyway `clean`, and it should only be used when you explicitly want to wipe stored EMF data.
+
+:::
 
 ## Migrating from Database V2
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/DangerousCommandConfirmation.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/DangerousCommandConfirmation.java
@@ -1,0 +1,43 @@
+package com.oheers.fish.commands;
+
+import org.bukkit.command.CommandSender;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class DangerousCommandConfirmation {
+    private static final long CONFIRMATION_WINDOW_MILLIS = 30_000L;
+    private static final Map<String, Long> pendingConfirmations = new ConcurrentHashMap<>();
+
+    private DangerousCommandConfirmation() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static boolean confirmOrRequest(
+        @NonNull CommandSender sender,
+        @NonNull String confirmationId,
+        @NonNull String confirmationCommand
+    ) {
+        long now = System.currentTimeMillis();
+        String key = buildKey(sender, confirmationId);
+        Long expiresAt = pendingConfirmations.get(key);
+
+        if (expiresAt != null && expiresAt >= now) {
+            pendingConfirmations.remove(key);
+            return true;
+        }
+
+        pendingConfirmations.put(key, now + CONFIRMATION_WINDOW_MILLIS);
+        sender.sendMessage(
+            "This command permanently deletes EMF database data. Run "
+                + confirmationCommand
+                + " again within 30 seconds to confirm."
+        );
+        return false;
+    }
+
+    private static @NonNull String buildKey(@NonNull CommandSender sender, @NonNull String confirmationId) {
+        return sender.getClass().getName() + ":" + sender.getName() + ":" + confirmationId;
+    }
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
@@ -31,12 +31,21 @@ import org.jdbi.v3.core.statement.PreparedBatch;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jspecify.annotations.NonNull;
 
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -243,6 +252,10 @@ public class Database implements DatabaseAPI {
         return connectionFactory.getType();
     }
 
+    public int resetPluginData() {
+        return withHandle(handle -> resetPluginData(handle.getConnection()), -1);
+    }
+
     @Override
     public UserFishStats getUserFishStats(int userId, String fishName, String fishRarity) {
         return withHandle(handle -> handle.createQuery("select user_id, fish_name, fish_rarity, first_catch_time, shortest_length, longest_length, quantity from " + userFishStatsTable + " where user_id = :user_id and fish_name = :fish_name and fish_rarity = :fish_rarity").bind("user_id", userId).bind("fish_name", fishName).bind("fish_rarity", fishRarity).mapTo(UserFishStats.class).findOne().orElse(null), null);
@@ -399,6 +412,133 @@ public class Database implements DatabaseAPI {
 
     private String fishStatsUpsertSql() {
         return sqlDialect.fishStatsUpsert(fishTable);
+    }
+
+    private int resetPluginData(@NonNull Connection connection) throws SQLException {
+        List<String> tables = discoverManagedTables(connection);
+        if (tables.isEmpty()) {
+            return 0;
+        }
+
+        String type = connectionFactory.getType().toUpperCase(Locale.ROOT);
+        switch (type) {
+            case "SQLITE" -> resetSqliteTables(connection, tables);
+            case "MYSQL", "MARIADB" -> resetMysqlTables(connection, tables);
+            case "H2" -> resetH2Tables(connection, tables);
+            case "POSTGRES", "POSTGRESQL" -> resetPostgresTables(connection, tables);
+            default -> throw new SQLException("Unsupported database type for reset: " + type);
+        }
+
+        EvenMoreFish.getInstance().getLogger().info("Reset EMF database tables: " + String.join(", ", tables));
+        return tables.size();
+    }
+
+    private @NonNull List<String> discoverManagedTables(@NonNull Connection connection) throws SQLException {
+        String prefix = MainConfig.getInstance().getPrefix();
+        String flywayTable = prefix + "flyway_schema_history";
+        DatabaseMetaData metaData = connection.getMetaData();
+        Map<String, String> tablesByLowerName = new LinkedHashMap<>();
+
+        collectManagedTables(metaData, connection.getCatalog(), null, prefix, flywayTable, tablesByLowerName);
+        collectManagedTables(metaData, null, null, prefix, flywayTable, tablesByLowerName);
+
+        return new ArrayList<>(tablesByLowerName.values());
+    }
+
+    private void collectManagedTables(
+        @NonNull DatabaseMetaData metaData,
+        String catalog,
+        String schema,
+        @NonNull String prefix,
+        @NonNull String flywayTable,
+        @NonNull Map<String, String> tablesByLowerName
+    ) throws SQLException {
+        try (ResultSet tables = metaData.getTables(catalog, schema, "%", new String[]{"TABLE"})) {
+            while (tables.next()) {
+                String tableName = tables.getString("TABLE_NAME");
+                if (tableName == null) {
+                    continue;
+                }
+
+                String normalizedName = tableName.toLowerCase(Locale.ROOT);
+                if (!normalizedName.startsWith(prefix.toLowerCase(Locale.ROOT))) {
+                    continue;
+                }
+                if (normalizedName.equals(flywayTable.toLowerCase(Locale.ROOT))) {
+                    continue;
+                }
+
+                tablesByLowerName.putIfAbsent(normalizedName, tableName);
+            }
+        }
+    }
+
+    private void resetSqliteTables(@NonNull Connection connection, @NonNull List<String> tables) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA foreign_keys = OFF");
+            try {
+                for (String table : tables) {
+                    statement.executeUpdate("DELETE FROM " + quotedIdentifier(connection, table));
+                }
+                statement.executeUpdate("DELETE FROM sqlite_sequence WHERE name IN (" + quotedStringList(tables) + ")");
+            } finally {
+                statement.execute("PRAGMA foreign_keys = ON");
+            }
+        }
+    }
+
+    private void resetMysqlTables(@NonNull Connection connection, @NonNull List<String> tables) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+            try {
+                for (String table : tables) {
+                    statement.executeUpdate("TRUNCATE TABLE " + quotedIdentifier(connection, table));
+                }
+            } finally {
+                statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+            }
+        }
+    }
+
+    private void resetH2Tables(@NonNull Connection connection, @NonNull List<String> tables) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET REFERENTIAL_INTEGRITY FALSE");
+            try {
+                for (String table : tables) {
+                    statement.executeUpdate("TRUNCATE TABLE " + quotedIdentifier(connection, table) + " RESTART IDENTITY");
+                }
+            } finally {
+                statement.execute("SET REFERENTIAL_INTEGRITY TRUE");
+            }
+        }
+    }
+
+    private void resetPostgresTables(@NonNull Connection connection, @NonNull List<String> tables) throws SQLException {
+        List<String> quotedTables = new ArrayList<>(tables.size());
+        for (String table : tables) {
+            quotedTables.add(quotedIdentifier(connection, table));
+        }
+
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate(
+                "TRUNCATE TABLE " + quotedTables.stream()
+                    .collect(Collectors.joining(", ")) + " RESTART IDENTITY"
+            );
+        }
+    }
+
+    private @NonNull String quotedIdentifier(@NonNull Connection connection, @NonNull String identifier) throws SQLException {
+        String quote = connection.getMetaData().getIdentifierQuoteString();
+        if (quote == null || quote.isBlank()) {
+            return identifier;
+        }
+        return quote + identifier.replace(quote, quote + quote) + quote;
+    }
+
+    private @NonNull String quotedStringList(@NonNull List<String> values) {
+        return values.stream()
+            .map(value -> "'" + value.replace("'", "''") + "'")
+            .collect(Collectors.joining(", "));
     }
 
     private <T> T withHandle(HandleCallback<T> callback, T fallback) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/manager/DataManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/manager/DataManager.java
@@ -157,6 +157,11 @@ public class DataManager<T> {
         flushDirty();
     }
 
+    public void clear() {
+        cache.clear();
+        dirtyKeys.clear();
+    }
+
     private void flushDirty() {
         if (dirtyKeys.isEmpty()) {
             return;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/manager/UserManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/manager/UserManager.java
@@ -86,6 +86,10 @@ public class UserManager implements Listener {
         return databaseWorker.query(() -> getUserId(uuid));
     }
 
+    public void clearCache() {
+        userCache.clear();
+    }
+
     private int loadOrCreateUser(final UUID uuid) {
         int id = database.getUserId(uuid);
         if (id == 0) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/permissions/AdminPerms.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/permissions/AdminPerms.java
@@ -13,4 +13,5 @@ public class AdminPerms {
     public static final String DATABASE_CLEAN = "emf.admin.debug.database.clean";
     public static final String DATABASE_FLYWAY = "emf.admin.debug.database.flyway";
     public static final String DATABASE_MIGRATE = "emf.admin.debug.database.migrate";
+    public static final String DATABASE_RESET = "emf.admin.debug.database.reset";
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/PluginDataManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/PluginDataManager.java
@@ -234,5 +234,42 @@ public class PluginDataManager {
         plugin.getLogger().info("Preloaded %d fish stats entries.".formatted(rows.size()));
     }
 
+    public int resetDatabaseData() {
+        if (database == null) {
+            return 0;
+        }
+
+        clearRuntimeCaches();
+        int resetTableCount = database.resetPluginData();
+        if (resetTableCount >= 0) {
+            preloadFishStats();
+        }
+        return resetTableCount;
+    }
+
+    private void clearRuntimeCaches() {
+        if (userManager != null) {
+            userManager.clearCache();
+        }
+        if (fishLogDataManager != null) {
+            fishLogDataManager.clear();
+        }
+        if (fishStatsDataManager != null) {
+            fishStatsDataManager.clear();
+        }
+        if (userFishStatsDataManager != null) {
+            userFishStatsDataManager.clear();
+        }
+        if (userReportDataManager != null) {
+            userReportDataManager.clear();
+        }
+        if (competitionDataManager != null) {
+            competitionDataManager.clear();
+        }
+
+        preloadedUserFishStats.clear();
+        fishStatsPreloaded = false;
+    }
+
 
 }

--- a/versions/1-20/src/main/java/org/evenmorefish/fish/commands/AdminDatabaseCommand.java
+++ b/versions/1-20/src/main/java/org/evenmorefish/fish/commands/AdminDatabaseCommand.java
@@ -3,6 +3,7 @@ package org.evenmorefish.fish.commands;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.utils.Scheduling;
 import com.oheers.fish.commands.CommandUtils;
+import com.oheers.fish.commands.DangerousCommandConfirmation;
 import dev.jorel.commandapi.CommandAPICommand;
 
 import java.util.List;
@@ -16,7 +17,8 @@ public class AdminDatabaseCommand extends CommandAPICommand {
                 dropFlywayCommand(),
                 repairFlywayCommand(),
                 cleanFlywayCommand(),
-                migrateToLatest()
+                migrateToLatest(),
+                resetDatabaseCommand()
         ));
     }
 
@@ -73,6 +75,35 @@ public class AdminDatabaseCommand extends CommandAPICommand {
                     }
                     EvenMoreFish.getInstance().getPluginDataManager().getDatabaseWorker()
                         .write(() -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().migrateFromDatabaseVersionToLatest());
+                });
+    }
+
+    public CommandAPICommand resetDatabaseCommand() {
+        return new CommandAPICommand("reset")
+                .withShortDescription("Reset the emf database.")
+                .withPermission("emf.admin.debug.database.reset")
+                .executes((commandSender, commandArguments) -> {
+                    if (CommandUtils.isLogDbError(commandSender)) {
+                        return;
+                    }
+                    if (!DangerousCommandConfirmation.confirmOrRequest(
+                        commandSender,
+                        "database-reset",
+                        "/emf admin database reset"
+                    )) {
+                        return;
+                    }
+
+                    commandSender.sendMessage("Resetting EMF database tables, check the logs.");
+                    EvenMoreFish.getInstance().getPluginDataManager().getDatabaseWorker()
+                        .writeResult(() -> EvenMoreFish.getInstance().getPluginDataManager().resetDatabaseData())
+                        .thenAccept(resetTableCount -> Scheduling.getInstance().runTask(() ->
+                            commandSender.sendMessage(
+                                resetTableCount < 0
+                                    ? "Failed to reset the EMF database. Check the logs."
+                                    : "Reset " + resetTableCount + " EMF database table(s)."
+                            )
+                        ));
                 });
     }
 

--- a/versions/1-21/1-4/src/main/java/org/evenmorefish/fish/commands/admin/subcommand/DatabaseSubcommand.java
+++ b/versions/1-21/1-4/src/main/java/org/evenmorefish/fish/commands/admin/subcommand/DatabaseSubcommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.utils.Scheduling;
 import com.oheers.fish.commands.CommandUtils;
+import com.oheers.fish.commands.DangerousCommandConfirmation;
 import com.oheers.fish.permissions.AdminPerms;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
@@ -27,6 +28,7 @@ public class DatabaseSubcommand {
             .then(repairFlyway())
             .then(cleanFlyway())
             .then(migrateToLatest())
+            .then(reset())
             .then(help());
     }
 
@@ -89,11 +91,40 @@ public class DatabaseSubcommand {
             });
     }
 
+    private @NonNull ArgumentBuilder<CommandSourceStack, ?> reset() {
+        return Commands.literal("reset")
+            .requires(source -> source.getSender().hasPermission(AdminPerms.DATABASE_RESET))
+            .executes(ctx -> {
+                CommandSender sender = ctx.getSource().getSender();
+                if (CommandUtils.isLogDbError(sender)) {
+                    return 1;
+                }
+                if (!DangerousCommandConfirmation.confirmOrRequest(
+                    sender,
+                    "database-reset",
+                    "/emf admin database reset"
+                )) {
+                    return 1;
+                }
+                sender.sendMessage("Resetting EMF database tables, check the logs.");
+                EvenMoreFish.getInstance().getPluginDataManager().getDatabaseWorker()
+                    .writeResult(() -> EvenMoreFish.getInstance().getPluginDataManager().resetDatabaseData())
+                    .thenAccept(resetTableCount -> Scheduling.getInstance().runTask(() ->
+                        sender.sendMessage(
+                            resetTableCount < 0
+                                ? "Failed to reset the EMF database. Check the logs."
+                                : "Reset " + resetTableCount + " EMF database table(s)."
+                        )
+                    ));
+                return 1;
+            });
+    }
+
     private @NonNull ArgumentBuilder<CommandSourceStack, ?> help() {
         return Commands.literal("help")
             .executes(ctx -> {
                 ctx.getSource().getSender().sendPlainMessage(
-                    "Available Commands: migrate-to-latest, clean-flyway, repair-flyway, drop-flyway"
+                    "Available Commands: migrate-to-latest, reset, clean-flyway, repair-flyway, drop-flyway"
                 );
                 return 1;
             });

--- a/versions/1-21/5-11/src/main/java/org/evenmorefish/fish/commands/admin/subcommand/DatabaseSubcommand.java
+++ b/versions/1-21/5-11/src/main/java/org/evenmorefish/fish/commands/admin/subcommand/DatabaseSubcommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.utils.Scheduling;
 import com.oheers.fish.commands.CommandUtils;
+import com.oheers.fish.commands.DangerousCommandConfirmation;
 import com.oheers.fish.permissions.AdminPerms;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
@@ -27,6 +28,7 @@ public class DatabaseSubcommand {
             .then(repairFlyway())
             .then(cleanFlyway())
             .then(migrateToLatest())
+            .then(reset())
             .then(help());
     }
 
@@ -89,11 +91,40 @@ public class DatabaseSubcommand {
             });
     }
 
+    private @NonNull ArgumentBuilder<CommandSourceStack, ?> reset() {
+        return Commands.literal("reset")
+            .requires(source -> source.getSender().hasPermission(AdminPerms.DATABASE_RESET))
+            .executes(ctx -> {
+                CommandSender sender = ctx.getSource().getSender();
+                if (CommandUtils.isLogDbError(sender)) {
+                    return 1;
+                }
+                if (!DangerousCommandConfirmation.confirmOrRequest(
+                    sender,
+                    "database-reset",
+                    "/emf admin database reset"
+                )) {
+                    return 1;
+                }
+                sender.sendMessage("Resetting EMF database tables, check the logs.");
+                EvenMoreFish.getInstance().getPluginDataManager().getDatabaseWorker()
+                    .writeResult(() -> EvenMoreFish.getInstance().getPluginDataManager().resetDatabaseData())
+                    .thenAccept(resetTableCount -> Scheduling.getInstance().runTask(() ->
+                        sender.sendMessage(
+                            resetTableCount < 0
+                                ? "Failed to reset the EMF database. Check the logs."
+                                : "Reset " + resetTableCount + " EMF database table(s)."
+                        )
+                    ));
+                return 1;
+            });
+    }
+
     private @NonNull ArgumentBuilder<CommandSourceStack, ?> help() {
         return Commands.literal("help")
             .executes(ctx -> {
                 ctx.getSource().getSender().sendPlainMessage(
-                    "Available Commands: migrate-to-latest, clean-flyway, repair-flyway, drop-flyway"
+                    "Available Commands: migrate-to-latest, reset, clean-flyway, repair-flyway, drop-flyway"
                 );
                 return 1;
             });

--- a/versions/26-1/src/main/java/org/evenmorefish/fish/commands/admin/subcommand/DatabaseSubcommand.java
+++ b/versions/26-1/src/main/java/org/evenmorefish/fish/commands/admin/subcommand/DatabaseSubcommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.utils.Scheduling;
 import com.oheers.fish.commands.CommandUtils;
+import com.oheers.fish.commands.DangerousCommandConfirmation;
 import com.oheers.fish.permissions.AdminPerms;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
@@ -27,6 +28,7 @@ public class DatabaseSubcommand {
             .then(repairFlyway())
             .then(cleanFlyway())
             .then(migrateToLatest())
+            .then(reset())
             .then(help());
     }
 
@@ -89,11 +91,40 @@ public class DatabaseSubcommand {
             });
     }
 
+    private @NonNull ArgumentBuilder<CommandSourceStack, ?> reset() {
+        return Commands.literal("reset")
+            .requires(source -> source.getSender().hasPermission(AdminPerms.DATABASE_RESET))
+            .executes(ctx -> {
+                CommandSender sender = ctx.getSource().getSender();
+                if (CommandUtils.isLogDbError(sender)) {
+                    return 1;
+                }
+                if (!DangerousCommandConfirmation.confirmOrRequest(
+                    sender,
+                    "database-reset",
+                    "/emf admin database reset"
+                )) {
+                    return 1;
+                }
+                sender.sendMessage("Resetting EMF database tables, check the logs.");
+                EvenMoreFish.getInstance().getPluginDataManager().getDatabaseWorker()
+                    .writeResult(() -> EvenMoreFish.getInstance().getPluginDataManager().resetDatabaseData())
+                    .thenAccept(resetTableCount -> Scheduling.getInstance().runTask(() ->
+                        sender.sendMessage(
+                            resetTableCount < 0
+                                ? "Failed to reset the EMF database. Check the logs."
+                                : "Reset " + resetTableCount + " EMF database table(s)."
+                        )
+                    ));
+                return 1;
+            });
+    }
+
     private @NonNull ArgumentBuilder<CommandSourceStack, ?> help() {
         return Commands.literal("help")
             .executes(ctx -> {
                 ctx.getSource().getSender().sendPlainMessage(
-                    "Available Commands: migrate-to-latest, clean-flyway, repair-flyway, drop-flyway"
+                    "Available Commands: migrate-to-latest, reset, clean-flyway, repair-flyway, drop-flyway"
                 );
                 return 1;
             });

--- a/versions/26-2/src/main/java/org/evenmorefish/fish/commands/admin/subcommand/DatabaseSubcommand.java
+++ b/versions/26-2/src/main/java/org/evenmorefish/fish/commands/admin/subcommand/DatabaseSubcommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.utils.Scheduling;
 import com.oheers.fish.commands.CommandUtils;
+import com.oheers.fish.commands.DangerousCommandConfirmation;
 import com.oheers.fish.permissions.AdminPerms;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
@@ -27,6 +28,7 @@ public class DatabaseSubcommand {
             .then(repairFlyway())
             .then(cleanFlyway())
             .then(migrateToLatest())
+            .then(reset())
             .then(help());
     }
 
@@ -89,11 +91,40 @@ public class DatabaseSubcommand {
             });
     }
 
+    private @NonNull ArgumentBuilder<CommandSourceStack, ?> reset() {
+        return Commands.literal("reset")
+            .requires(source -> source.getSender().hasPermission(AdminPerms.DATABASE_RESET))
+            .executes(ctx -> {
+                CommandSender sender = ctx.getSource().getSender();
+                if (CommandUtils.isLogDbError(sender)) {
+                    return 1;
+                }
+                if (!DangerousCommandConfirmation.confirmOrRequest(
+                    sender,
+                    "database-reset",
+                    "/emf admin database reset"
+                )) {
+                    return 1;
+                }
+                sender.sendMessage("Resetting EMF database tables, check the logs.");
+                EvenMoreFish.getInstance().getPluginDataManager().getDatabaseWorker()
+                    .writeResult(() -> EvenMoreFish.getInstance().getPluginDataManager().resetDatabaseData())
+                    .thenAccept(resetTableCount -> Scheduling.getInstance().runTask(() ->
+                        sender.sendMessage(
+                            resetTableCount < 0
+                                ? "Failed to reset the EMF database. Check the logs."
+                                : "Reset " + resetTableCount + " EMF database table(s)."
+                        )
+                    ));
+                return 1;
+            });
+    }
+
     private @NonNull ArgumentBuilder<CommandSourceStack, ?> help() {
         return Commands.literal("help")
             .executes(ctx -> {
                 ctx.getSource().getSender().sendPlainMessage(
-                    "Available Commands: migrate-to-latest, clean-flyway, repair-flyway, drop-flyway"
+                    "Available Commands: migrate-to-latest, reset, clean-flyway, repair-flyway, drop-flyway"
                 );
                 return 1;
             });


### PR DESCRIPTION
## Description
Adds an admin database reset command that clears EMF-managed database tables without using Flyway `clean`, protects it behind a 30-second reconfirmation flow, and documents the new command and permission.

---

### What has changed?
- Added `database reset` command support across the versioned admin command implementations.
- Added runtime cache clearing and fish stat re-preload after reset so in-memory state does not survive the wipe.
- Added `emf.admin.debug.database.reset` to admin permissions.
- Added a shared destructive-command confirmation helper requiring the same reset command to be run twice within 30 seconds before execution. - so hey, if we ever need a confirmation pattern again, we have it already :)

---

### Related Issues
Fixes the missing admin workflow for explicitly wiping EMF database data without relying on Flyway `clean`, and reduces the risk of accidental destructive execution by requiring confirmation.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.